### PR TITLE
1주차 과제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/abc/mart/common/annotation/AggregateRoot.java
+++ b/src/main/java/com/abc/mart/common/annotation/AggregateRoot.java
@@ -1,0 +1,4 @@
+package com.abc.mart.common.annotation;
+
+public @interface AggregateRoot {
+}

--- a/src/main/java/com/abc/mart/common/annotation/ValueObject.java
+++ b/src/main/java/com/abc/mart/common/annotation/ValueObject.java
@@ -1,0 +1,4 @@
+package com.abc.mart.common.annotation;
+
+public @interface ValueObject {
+}

--- a/src/main/java/com/abc/mart/member/domain/Member.java
+++ b/src/main/java/com/abc/mart/member/domain/Member.java
@@ -1,0 +1,26 @@
+package com.abc.mart.member.domain;
+
+import com.abc.mart.common.annotation.AggregateRoot;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AggregateRoot
+@NoArgsConstructor
+@AllArgsConstructor
+public class Member {
+
+    @Getter
+    String memberId;
+
+    @Getter
+    String name;
+
+    @Getter
+    String email;
+    String phoneNum;
+
+    public static Member of(String memberId, String name, String email, String phoneNum) {
+        return new Member(memberId, name, email, phoneNum);
+    }
+}

--- a/src/main/java/com/abc/mart/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/abc/mart/member/domain/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.abc.mart.member.domain.repository;
+
+import com.abc.mart.member.domain.Member;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository {
+
+    public Member findByMemberId(String memberId);
+}

--- a/src/main/java/com/abc/mart/order/domain/Customer.java
+++ b/src/main/java/com/abc/mart/order/domain/Customer.java
@@ -1,0 +1,17 @@
+package com.abc.mart.order.domain;
+
+import com.abc.mart.common.annotation.ValueObject;
+import com.abc.mart.member.domain.Member;
+import lombok.AllArgsConstructor;
+
+@ValueObject
+@AllArgsConstructor
+public class Customer {
+    String memberId;
+    String name;
+    String email;
+
+    public static Customer from(Member member){
+        return new Customer(member.getMemberId(), member.getName(), member.getEmail());
+    }
+}

--- a/src/main/java/com/abc/mart/order/domain/Order.java
+++ b/src/main/java/com/abc/mart/order/domain/Order.java
@@ -1,0 +1,67 @@
+package com.abc.mart.order.domain;
+
+import com.abc.mart.common.annotation.AggregateRoot;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@AggregateRoot
+public class Order {
+
+    @Getter
+    private OrderId orderId;
+
+    @Getter
+    private Map<String, OrderItem> orderItems;
+    private Customer customer;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static Order createOrder(List<OrderItem> orderItems, Customer customer) {
+        Order order = new Order();
+        var now = LocalDateTime.now();
+
+        OrderId id = OrderId.generate(customer.memberId, now);
+        order.orderId = id;
+
+        order.setOrderItems(orderItems);
+        order.customer = customer;
+
+        order.createdAt = now;
+        order.updatedAt = now;
+
+        return order;
+    }
+
+    public void setOrderItems(List<OrderItem> orderItems){
+        var orderItemMap = new HashMap<String, OrderItem>();
+        for (OrderItem orderItem : orderItems) {
+            orderItemMap.put(orderItem.getProductId(), orderItem);
+        }
+        this.orderItems = orderItemMap;
+    }
+
+    public void cancelOrder() {
+        for(var orderItem : orderItems.values()){
+            orderItem.cancelOrderItem();
+        }
+    }
+
+    public void partialCancelOrder(List<String> cancelledOrderIds) {
+        for(var cancelledOrderId : cancelledOrderIds){
+            orderItems.get(cancelledOrderId).cancelOrderItem();
+        }
+    }
+
+    public long calculateSalesAmountOfSpecificProduct(String productId){
+        return this.orderItems.get(productId).getTotalPrice();
+    }
+
+    public long calculateTotalPrice() {
+        return this.orderItems.values().stream().mapToLong(OrderItem::getTotalPrice).sum();
+    }
+
+}

--- a/src/main/java/com/abc/mart/order/domain/OrderId.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderId.java
@@ -1,0 +1,20 @@
+package com.abc.mart.order.domain;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+public record OrderId (
+        String id
+){
+
+    public static OrderId of(String id) {
+        return new OrderId(id);
+    }
+
+    public static OrderId generate(String customerId, LocalDateTime createdDt){
+        String ts = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(createdDt);
+        String randomId = UUID.randomUUID().toString().replace("-", "");
+        return new OrderId(customerId + "-" + ts + "-" + randomId);
+    }
+}

--- a/src/main/java/com/abc/mart/order/domain/OrderItem.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderItem.java
@@ -1,0 +1,40 @@
+package com.abc.mart.order.domain;
+
+import com.abc.mart.common.annotation.ValueObject;
+import com.abc.mart.product.domain.Product;
+import lombok.Getter;
+import lombok.Setter;
+
+@ValueObject
+//Has the same lifecycle with Order entity
+public class OrderItem {
+
+    @Setter
+    @Getter
+    private String productId;
+    private Long orderedPrice; //snapshot of the price when the order was placed
+    private int quantity;
+    private long totalPrice;
+
+    @Getter
+    private OrderState orderState;
+
+    public static OrderItem of(Product product, int quantity){
+        var orderItem = new OrderItem();
+        orderItem.productId = product.getId();
+        orderItem.orderedPrice = product.getPrice();
+        orderItem.quantity = quantity;
+        orderItem.totalPrice = orderItem.getTotalPrice();
+        orderItem.orderState = OrderState.PREPARING;
+
+        return orderItem;
+    }
+
+    public void cancelOrderItem(){
+        this.orderState = OrderState.CANCELLED;
+    }
+
+    public Long getTotalPrice(){
+        return quantity * orderedPrice;
+    }
+}

--- a/src/main/java/com/abc/mart/order/domain/OrderItem.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderItem.java
@@ -14,7 +14,6 @@ public class OrderItem {
     private String productId;
     private Long orderedPrice; //snapshot of the price when the order was placed
     private int quantity;
-    private long totalPrice;
 
     @Getter
     private OrderState orderState;
@@ -24,7 +23,6 @@ public class OrderItem {
         orderItem.productId = product.getId();
         orderItem.orderedPrice = product.getPrice();
         orderItem.quantity = quantity;
-        orderItem.totalPrice = orderItem.getTotalPrice();
         orderItem.orderState = OrderState.PREPARING;
 
         return orderItem;

--- a/src/main/java/com/abc/mart/order/domain/OrderState.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderState.java
@@ -1,0 +1,5 @@
+package com.abc.mart.order.domain;
+
+public enum OrderState {
+    PREPARING, SHIPPED, CANCELLED, COMPLETED
+}

--- a/src/main/java/com/abc/mart/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/abc/mart/order/domain/repository/OrderRepository.java
@@ -1,0 +1,11 @@
+package com.abc.mart.order.domain.repository;
+
+import com.abc.mart.order.domain.Order;
+import com.abc.mart.order.domain.OrderId;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository {
+    void placeOrder(Order order);
+    Order findById(OrderId orderId);
+}

--- a/src/main/java/com/abc/mart/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/abc/mart/order/domain/repository/OrderRepository.java
@@ -2,10 +2,18 @@ package com.abc.mart.order.domain.repository;
 
 import com.abc.mart.order.domain.Order;
 import com.abc.mart.order.domain.OrderId;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public interface OrderRepository {
+public interface OrderRepository extends JpaSpecificationExecutor<Order> {
+
     void placeOrder(Order order);
     Order findById(OrderId orderId);
+
+    //jpa를 아직 사용하지 않지만 spec 패턴 실습을 위해 사용
+    List<Order> findByTerm(Specification spec);
 }

--- a/src/main/java/com/abc/mart/order/domain/repository/OrderSpecification.java
+++ b/src/main/java/com/abc/mart/order/domain/repository/OrderSpecification.java
@@ -1,0 +1,14 @@
+package com.abc.mart.order.domain.repository;
+
+import com.abc.mart.order.domain.Order;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+
+public class OrderSpecification {
+    public static Specification<Order> between(LocalDateTime from, LocalDateTime to) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.between(root.get("createdDt"), from, to);
+
+    }
+}

--- a/src/main/java/com/abc/mart/order/domain/repository/ProductRepository.java
+++ b/src/main/java/com/abc/mart/order/domain/repository/ProductRepository.java
@@ -1,0 +1,11 @@
+package com.abc.mart.order.domain.repository;
+
+import com.abc.mart.product.domain.Product;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProductRepository {
+    List<Product> findByProductId(List<String> productId);
+}

--- a/src/main/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecase.java
@@ -1,0 +1,20 @@
+package com.abc.mart.order.usecase;
+
+import com.abc.mart.order.domain.OrderId;
+import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.order.usecase.dto.CalcuateSalesAmountRequest;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CalculateSalesAmountUsecase {
+
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public long calculateSalesAmount(CalcuateSalesAmountRequest request){
+        var order = orderRepository.findById(OrderId.of(request.orderId()));
+
+        return order.calculateSalesAmountOfSpecificProduct(request.productId());
+    }
+}

--- a/src/main/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecase.java
@@ -3,15 +3,15 @@ package com.abc.mart.order.usecase;
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.order.domain.repository.OrderSpecification;
 import com.abc.mart.order.usecase.dto.CalculateSalesRequest;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 public class CalculateSalesAmountUsecase {
 
     private final OrderRepository orderRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public long calculateSalesAmount(CalculateSalesRequest request) {
         var orders = orderRepository.findByTerm(OrderSpecification.between(request.from(), request.to()));
 

--- a/src/main/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecase.java
@@ -2,7 +2,7 @@ package com.abc.mart.order.usecase;
 
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.order.domain.repository.OrderSpecification;
-import com.abc.mart.order.usecase.dto.CalcuateSalesAmountRequest;
+import com.abc.mart.order.usecase.dto.CalculateSalesRequest;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
@@ -12,7 +12,7 @@ public class CalculateSalesAmountUsecase {
     private final OrderRepository orderRepository;
 
     @Transactional
-    public long calculateSalesAmount(CalcuateSalesAmountRequest request) {
+    public long calculateSalesAmount(CalculateSalesRequest request) {
         var orders = orderRepository.findByTerm(OrderSpecification.between(request.from(), request.to()));
 
         if (orders.isEmpty()) return 0;

--- a/src/main/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecase.java
@@ -1,7 +1,7 @@
 package com.abc.mart.order.usecase;
 
-import com.abc.mart.order.domain.OrderId;
 import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.order.domain.repository.OrderSpecification;
 import com.abc.mart.order.usecase.dto.CalcuateSalesAmountRequest;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +12,13 @@ public class CalculateSalesAmountUsecase {
     private final OrderRepository orderRepository;
 
     @Transactional
-    public long calculateSalesAmount(CalcuateSalesAmountRequest request){
-        var order = orderRepository.findById(OrderId.of(request.orderId()));
+    public long calculateSalesAmount(CalcuateSalesAmountRequest request) {
+        var orders = orderRepository.findByTerm(OrderSpecification.between(request.from(), request.to()));
 
-        return order.calculateSalesAmountOfSpecificProduct(request.productId());
+        if (orders.isEmpty()) return 0;
+
+        return orders.stream()
+                .mapToLong(o -> o.calculateSalesAmountOfSpecificProduct(request.productId()))
+                .sum();
     }
 }

--- a/src/main/java/com/abc/mart/order/usecase/CancelOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/CancelOrderUsecase.java
@@ -1,0 +1,23 @@
+package com.abc.mart.order.usecase;
+
+import com.abc.mart.order.domain.Order;
+import com.abc.mart.order.domain.OrderId;
+import com.abc.mart.order.domain.repository.OrderRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CancelOrderUsecase {
+
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public Order cancelOrder(String orderId){
+        var order = orderRepository.findById(OrderId.of(orderId));
+
+        order.cancelOrder();
+        return order;
+    }
+}

--- a/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
@@ -1,0 +1,25 @@
+package com.abc.mart.order.usecase;
+
+import com.abc.mart.order.domain.Order;
+import com.abc.mart.order.domain.OrderId;
+import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.order.usecase.dto.PartialOrderCancelRequest;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PartialCancelOrderUsecase {
+
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public Order cancelPartialOrder(PartialOrderCancelRequest request){
+        var order = orderRepository.findById(OrderId.of(request.orderId()));
+
+        order.partialCancelOrder(request.cancelProductIds());
+
+        return order;
+    }
+}

--- a/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
@@ -1,0 +1,48 @@
+package com.abc.mart.order.usecase;
+
+import com.abc.mart.member.domain.repository.MemberRepository;
+import com.abc.mart.order.domain.Customer;
+import com.abc.mart.order.domain.Order;
+import com.abc.mart.order.domain.OrderItem;
+import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.order.domain.repository.ProductRepository;
+import com.abc.mart.order.usecase.dto.OrderRequest;
+import com.abc.mart.product.domain.Product;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceOrderUsecase {
+
+    private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public Order placeOrder(OrderRequest orderRequest) {
+
+        var customer = Customer.from(memberRepository.findByMemberId(orderRequest.orderMemberId()));
+
+        var productIds = orderRequest.orderItemRequestList().stream()
+                .map(OrderRequest.OrderItemRequest::productId).toList();
+
+        var productMap = productRepository.findByProductId(productIds).stream().collect(Collectors.toMap(Product::getId, p -> p));
+
+        var orderItems = orderRequest.orderItemRequestList().stream().map(orderItemRequest -> {
+            var product = productMap.get(orderItemRequest.productId());
+            var quantity = orderItemRequest.quantity();
+            return OrderItem.of(product, quantity);
+        }).toList();
+
+        var order = Order.createOrder(orderItems, customer);
+
+        orderRepository.placeOrder(order);
+
+        return order;
+    }
+
+}

--- a/src/main/java/com/abc/mart/order/usecase/dto/CalcuateSalesAmountRequest.java
+++ b/src/main/java/com/abc/mart/order/usecase/dto/CalcuateSalesAmountRequest.java
@@ -2,11 +2,11 @@ package com.abc.mart.order.usecase.dto;
 
 import lombok.Builder;
 
-import java.util.List;
-
+import java.time.LocalDateTime;
 @Builder
 public record CalcuateSalesAmountRequest(
-        String orderId,
+        LocalDateTime from,
+        LocalDateTime to,
         String productId
 ) {
 }

--- a/src/main/java/com/abc/mart/order/usecase/dto/CalcuateSalesAmountRequest.java
+++ b/src/main/java/com/abc/mart/order/usecase/dto/CalcuateSalesAmountRequest.java
@@ -1,0 +1,12 @@
+package com.abc.mart.order.usecase.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CalcuateSalesAmountRequest(
+        String orderId,
+        String productId
+) {
+}

--- a/src/main/java/com/abc/mart/order/usecase/dto/CalculateSalesRequest.java
+++ b/src/main/java/com/abc/mart/order/usecase/dto/CalculateSalesRequest.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 import java.time.LocalDateTime;
 @Builder
-public record CalcuateSalesAmountRequest(
+public record CalculateSalesRequest(
         LocalDateTime from,
         LocalDateTime to,
         String productId

--- a/src/main/java/com/abc/mart/order/usecase/dto/OrderRequest.java
+++ b/src/main/java/com/abc/mart/order/usecase/dto/OrderRequest.java
@@ -1,0 +1,20 @@
+package com.abc.mart.order.usecase.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record OrderRequest(
+        String orderMemberId,
+        List<OrderItemRequest> orderItemRequestList
+) {
+
+    @Builder
+    public record OrderItemRequest(
+            String productId,
+            int quantity
+    ){
+
+    }
+}

--- a/src/main/java/com/abc/mart/order/usecase/dto/PartialOrderCancelRequest.java
+++ b/src/main/java/com/abc/mart/order/usecase/dto/PartialOrderCancelRequest.java
@@ -1,0 +1,12 @@
+package com.abc.mart.order.usecase.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PartialOrderCancelRequest(
+        String orderId,
+        List<String> cancelProductIds
+) {
+}

--- a/src/main/java/com/abc/mart/product/domain/Product.java
+++ b/src/main/java/com/abc/mart/product/domain/Product.java
@@ -1,0 +1,18 @@
+package com.abc.mart.product.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class Product {
+
+    @Getter
+    private String id;
+    private String name;
+    @Getter
+    private long price;
+
+    public static Product of(String id, String name, long price) {
+        return new Product(id, name, price);
+    }
+}

--- a/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
@@ -3,7 +3,7 @@ package com.abc.mart.order.usecase;
 import com.abc.mart.member.domain.Member;
 import com.abc.mart.order.domain.*;
 import com.abc.mart.order.domain.repository.OrderRepository;
-import com.abc.mart.order.usecase.dto.CalcuateSalesAmountRequest;
+import com.abc.mart.order.usecase.dto.CalculateSalesRequest;
 import com.abc.mart.product.domain.Product;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -51,7 +51,7 @@ class CalculateSalesAmountUsecaseTest {
 
 
         //when
-        var calculateSalesAmountRequest = CalcuateSalesAmountRequest.builder()
+        var calculateSalesAmountRequest = CalculateSalesRequest.builder()
                 .productId(productId1).from(from).to(to).build();
 
         var res = calculateSalesAmountUsecase.calculateSalesAmount(calculateSalesAmountRequest);

--- a/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 class CalculateSalesAmountUsecaseTest {
@@ -32,28 +33,31 @@ class CalculateSalesAmountUsecaseTest {
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
-        var order = Order.createOrder(
+        var order1 = Order.createOrder(
                 List.of(OrderItem.of(products.getFirst(), 10), OrderItem.of(products.getLast(), 3)), customer
         );
+        var order2 = Order.createOrder(
+                List.of(OrderItem.of(products.getFirst(), 7), OrderItem.of(products.getLast(), 2)), customer
+        );
 
-        var now = LocalDateTime.now();
-        var orderId = OrderId.generate(orderMemberId, now);
-        when(orderRepository.findById(orderId)).thenReturn(order);
+        var order3 = Order.createOrder(
+                List.of(OrderItem.of(products.getFirst(), 6), OrderItem.of(products.getLast(), 2)), customer
+        );
+
+        var from = LocalDateTime.now().minusMonths(1);
+        var to = LocalDateTime.now();
+
+        when(orderRepository.findByTerm(any())).thenReturn(List.of(order1, order2, order3));
 
 
         //when
-        var calculateSalesAmountRequest = CalcuateSalesAmountRequest.builder().productId(productId1).orderId(orderId.id()).build();
+        var calculateSalesAmountRequest = CalcuateSalesAmountRequest.builder()
+                .productId(productId1).from(from).to(to).build();
+
         var res = calculateSalesAmountUsecase.calculateSalesAmount(calculateSalesAmountRequest);
 
         //then
-        assertEquals(100000, res);
-
-        //when
-        var calculateSalesAmountRequest2 = CalcuateSalesAmountRequest.builder().productId(productId2).orderId(orderId.id()).build();
-        var res2 = calculateSalesAmountUsecase.calculateSalesAmount(calculateSalesAmountRequest2);
-
-        //then
-        assertEquals(60000, res2);
+        assertEquals(230000, res);
 
     }
 

--- a/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
@@ -1,0 +1,60 @@
+package com.abc.mart.order.usecase;
+
+import com.abc.mart.member.domain.Member;
+import com.abc.mart.order.domain.*;
+import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.order.usecase.dto.CalcuateSalesAmountRequest;
+import com.abc.mart.product.domain.Product;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class CalculateSalesAmountUsecaseTest {
+
+    OrderRepository orderRepository = Mockito.mock(OrderRepository.class);
+    CalculateSalesAmountUsecase calculateSalesAmountUsecase = new CalculateSalesAmountUsecase(orderRepository);
+
+    @Test
+    void CalculateSalesAmountUsecaseTest() {
+        //given
+        var productId1 = "productId1";
+        var productId2 = "productId2";
+        var price1 = 10000;
+        var price2 = 20000;
+
+        var orderMemberId = "memberId";
+        var products = List.of(Product.of(productId1, "productName", price1), Product.of(productId2, "productName", price2));
+
+        var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
+
+        var order = Order.createOrder(
+                List.of(OrderItem.of(products.getFirst(), 10), OrderItem.of(products.getLast(), 3)), customer
+        );
+
+        var now = LocalDateTime.now();
+        var orderId = OrderId.generate(orderMemberId, now);
+        when(orderRepository.findById(orderId)).thenReturn(order);
+
+
+        //when
+        var calculateSalesAmountRequest = CalcuateSalesAmountRequest.builder().productId(productId1).orderId(orderId.id()).build();
+        var res = calculateSalesAmountUsecase.calculateSalesAmount(calculateSalesAmountRequest);
+
+        //then
+        assertEquals(100000, res);
+
+        //when
+        var calculateSalesAmountRequest2 = CalcuateSalesAmountRequest.builder().productId(productId2).orderId(orderId.id()).build();
+        var res2 = calculateSalesAmountUsecase.calculateSalesAmount(calculateSalesAmountRequest2);
+
+        //then
+        assertEquals(60000, res2);
+
+    }
+
+}

--- a/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
@@ -1,0 +1,52 @@
+package com.abc.mart.order.usecase;
+
+import com.abc.mart.member.domain.Member;
+import com.abc.mart.order.domain.*;
+import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.order.usecase.dto.PartialOrderCancelRequest;
+import com.abc.mart.product.domain.Product;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class CancelOrderUsecaseTest {
+
+    OrderRepository orderRepository = Mockito.mock(OrderRepository.class);
+    CancelOrderUsecase usecase = new CancelOrderUsecase(orderRepository);
+
+    @Test
+    void cancelPartialOrder() {
+        //given
+        var productId1 = "productId1";
+        var productId2 = "productId2";
+        var price1 = 10000;
+        var price2 = 20000;
+
+        var orderMemberId = "memberId";
+        var products = List.of(Product.of(productId1, "productName", price1), Product.of(productId2, "productName", price2));
+
+        var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
+
+        var order = Order.createOrder(
+                List.of(OrderItem.of(products.getFirst(), 10), OrderItem.of(products.getLast(), 3)), customer
+        );
+
+        var now = LocalDateTime.now();
+        var orderId = OrderId.generate(orderMemberId, now);
+        when(orderRepository.findById(orderId)).thenReturn(order);
+
+
+        //when
+        var res = usecase.cancelOrder(orderId.id());
+
+        //then
+        assertEquals(OrderState.CANCELLED, res.getOrderItems().get(productId1).getOrderState());
+        assertEquals(OrderState.CANCELLED, res.getOrderItems().get(productId2).getOrderState());
+    }
+
+}

--- a/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
@@ -1,0 +1,55 @@
+package com.abc.mart.order.usecase;
+
+import com.abc.mart.member.domain.Member;
+import com.abc.mart.order.domain.*;
+import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.order.usecase.dto.OrderRequest;
+import com.abc.mart.order.usecase.dto.PartialOrderCancelRequest;
+import com.abc.mart.product.domain.Product;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class PartialCancelOrderUsecaseTest {
+
+    OrderRepository orderRepository = Mockito.mock(OrderRepository.class);
+    PartialCancelOrderUsecase usecase = new PartialCancelOrderUsecase(orderRepository);
+
+    @Test
+    void cancelPartialOrder() {
+        //given
+        var productId1 = "productId1";
+        var productId2 = "productId2";
+        var price1 = 10000;
+        var price2 = 20000;
+
+        var orderMemberId = "memberId";
+        var products = List.of(Product.of(productId1, "productName", price1), Product.of(productId2, "productName", price2));
+
+        var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
+
+        var order = Order.createOrder(
+                List.of(OrderItem.of(products.getFirst(), 10), OrderItem.of(products.getLast(), 3)), customer
+        );
+
+        var now = LocalDateTime.now();
+        var orderId = OrderId.generate(orderMemberId, now);
+        when(orderRepository.findById(orderId)).thenReturn(order);
+
+
+        var partialCancelRequest = PartialOrderCancelRequest.builder().orderId(orderId.id()).cancelProductIds(List.of(productId1)).build();
+
+        //when
+        var res = usecase.cancelPartialOrder(partialCancelRequest);
+
+        //then
+        assertEquals(OrderState.CANCELLED, res.getOrderItems().get(productId1).getOrderState());
+        assertEquals(OrderState.PREPARING, res.getOrderItems().get(productId2).getOrderState());
+    }
+
+}

--- a/src/test/java/com/abc/mart/order/usecase/PlaceOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PlaceOrderUsecaseTest.java
@@ -1,0 +1,62 @@
+package com.abc.mart.order.usecase;
+
+import com.abc.mart.member.domain.Member;
+import com.abc.mart.member.domain.repository.MemberRepository;
+import com.abc.mart.order.domain.OrderState;
+import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.order.domain.repository.ProductRepository;
+import com.abc.mart.order.usecase.dto.OrderRequest;
+import com.abc.mart.product.domain.Product;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PlaceOrderUsecaseTest {
+
+    MemberRepository memberRepository = mock(MemberRepository.class);
+    OrderRepository orderRepository = mock(OrderRepository.class);
+    ProductRepository productRepository = mock(ProductRepository.class);
+
+    PlaceOrderUsecase placeOrderUsecase = new PlaceOrderUsecase(productRepository, memberRepository, orderRepository);
+
+    @Test
+    public void placeOrderTest() {
+        //given
+        var productId1 = "productId1";
+        var productId2 = "productId2";
+        var price1 = 10000;
+        var price2 = 20000;
+
+        var orderMemberId = "memberId";
+
+        var orderRequest = OrderRequest.builder()
+                .orderItemRequestList(
+                        List.of(OrderRequest.OrderItemRequest.builder()
+                                .productId(productId1).quantity(1).build(),
+                                OrderRequest.OrderItemRequest.builder().productId(productId2).
+                                        quantity(3).build())
+                ).orderMemberId(orderMemberId).build();
+
+        var member = Member.of(orderMemberId, "memberName", "email", "phoneNum");
+        var productIds = List.of(productId1, productId2);
+        var products = List.of(Product.of(productId1, "productName", price1), Product.of(productId2, "productName", price2));
+
+        when(memberRepository.findByMemberId(orderMemberId)).thenReturn(member);
+        when(productRepository.findByProductId(productIds)).thenReturn(products);
+
+        //when
+        var result = placeOrderUsecase.placeOrder(orderRequest);
+
+        //then
+        assertEquals(70000, result.calculateTotalPrice());
+        assertEquals(OrderState.PREPARING, result.getOrderItems().get(productId1).getOrderState());
+        assertEquals(OrderState.PREPARING, result.getOrderItems().get(productId2).getOrderState());
+        assertEquals(10000, result.getOrderItems().get(productId1).getTotalPrice());
+        assertEquals(60000, result.getOrderItems().get(productId2).getTotalPrice());
+    }
+
+}


### PR DESCRIPTION
뒷마당 달란트 매장에서 사용할 판매 장부를 만들어보자!

매장에서 판매된 물품의 개수를 관리하고자 한다.
모든 거래는 현금으로 이루어진다.

[최소 기능]

1. 주문 - PlaceOrderUsecase
2. 취소 - CancelOrderUsecase
3. 부분 취소 - PartialCancelOrderUsecase
4. 상품 별 판매 금액 조회 - CalculateSalesAmountUsecase

[도메인 설계]

<img width="1111" alt="image" src="https://github.com/user-attachments/assets/80de42d7-4921-4ea5-8919-5185a7c57ef3" />
