### PR TITLE
Week 2 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework:spring-tx'
     implementation 'org.springframework:spring-aop'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework:spring-tx'
+    implementation 'org.springframework:spring-aop'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/abc/mart/common/annotation/Entity.java
+++ b/src/main/java/com/abc/mart/common/annotation/Entity.java
@@ -1,0 +1,4 @@
+package com.abc.mart.common.annotation;
+
+public @interface Entity {
+}

--- a/src/main/java/com/abc/mart/order/domain/Order.java
+++ b/src/main/java/com/abc/mart/order/domain/Order.java
@@ -69,4 +69,8 @@ public class Order {
         return this.orderItems.values().stream().mapToLong(OrderItem::getTotalPrice).sum();
     }
 
+    public void orderGetPaid() {
+        this.orderStatus = OrderStatus.PAID;
+    }
+
 }

--- a/src/main/java/com/abc/mart/order/domain/Order.java
+++ b/src/main/java/com/abc/mart/order/domain/Order.java
@@ -19,6 +19,9 @@ public class Order {
 
     @Getter
     Map<String, OrderItem> orderItems;
+
+    @Getter
+    OrderStatus orderStatus;
     Customer customer;
     LocalDateTime createdAt;
     LocalDateTime updatedAt;
@@ -32,7 +35,7 @@ public class Order {
         order.customer = customer;
         order.createdAt = now;
         order.updatedAt = now;
-
+        order.orderStatus = OrderStatus.REQUESTED;
         return order;
     }
 
@@ -44,10 +47,12 @@ public class Order {
         this.orderItems = orderItemMap;
     }
 
+
     public void cancelOrder() {
         for(var orderItem : orderItems.values()){
             orderItem.cancelOrderItem();
         }
+        orderStatus = OrderStatus.CANCELLED;
     }
 
     public void partialCancelOrder(List<String> cancelledOrderIds) {

--- a/src/main/java/com/abc/mart/order/domain/Order.java
+++ b/src/main/java/com/abc/mart/order/domain/Order.java
@@ -1,7 +1,9 @@
 package com.abc.mart.order.domain;
 
 import com.abc.mart.common.annotation.AggregateRoot;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.experimental.FieldDefaults;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -9,27 +11,25 @@ import java.util.List;
 import java.util.Map;
 
 @AggregateRoot
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class Order {
 
     @Getter
-    private OrderId orderId;
+    OrderId orderId;
 
     @Getter
-    private Map<String, OrderItem> orderItems;
-    private Customer customer;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    Map<String, OrderItem> orderItems;
+    Customer customer;
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
 
-    public static Order createOrder(List<OrderItem> orderItems, Customer customer) {
+    public static Order createOrder(Customer customer) {
         Order order = new Order();
         var now = LocalDateTime.now();
 
         OrderId id = OrderId.generate(customer.memberId, now);
         order.orderId = id;
-
-        order.setOrderItems(orderItems);
         order.customer = customer;
-
         order.createdAt = now;
         order.updatedAt = now;
 

--- a/src/main/java/com/abc/mart/order/domain/OrderId.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderId.java
@@ -1,9 +1,12 @@
 package com.abc.mart.order.domain;
 
+import com.abc.mart.common.annotation.ValueObject;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
+@ValueObject
 public record OrderId (
         String id
 ){

--- a/src/main/java/com/abc/mart/order/domain/OrderItem.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderItem.java
@@ -1,25 +1,27 @@
 package com.abc.mart.order.domain;
 
-import com.abc.mart.common.annotation.ValueObject;
+import com.abc.mart.common.annotation.Entity;
 import com.abc.mart.product.domain.Product;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.experimental.FieldDefaults;
 
-@ValueObject
-//Has the same lifecycle with Order entity
+@Entity
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class OrderItem {
 
-    @Setter
+    OrderItemId orderItemId;
     @Getter
-    private String productId;
-    private Long orderedPrice; //snapshot of the price when the order was placed
-    private int quantity;
+    String productId;
+    Long orderedPrice; //snapshot of the price when the order was placed
+    int quantity;
 
     @Getter
-    private OrderState orderState;
+    OrderState orderState;
 
-    public static OrderItem of(Product product, int quantity){
+    public static OrderItem of(Product product, int quantity, OrderId orderId, int sequence){
         var orderItem = new OrderItem();
+        orderItem.orderItemId = OrderItemId.generate(orderId, product.getId(), sequence);
         orderItem.productId = product.getId();
         orderItem.orderedPrice = product.getPrice();
         orderItem.quantity = quantity;

--- a/src/main/java/com/abc/mart/order/domain/OrderItem.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderItem.java
@@ -17,7 +17,7 @@ public class OrderItem {
     int quantity;
 
     @Getter
-    OrderState orderState;
+    OrderItemState orderItemState;
 
     public static OrderItem of(Product product, int quantity, OrderId orderId, int sequence){
         var orderItem = new OrderItem();
@@ -25,13 +25,17 @@ public class OrderItem {
         orderItem.productId = product.getId();
         orderItem.orderedPrice = product.getPrice();
         orderItem.quantity = quantity;
-        orderItem.orderState = OrderState.PREPARING;
+        orderItem.orderItemState = OrderItemState.PREPARING;
 
         return orderItem;
     }
 
     public void cancelOrderItem(){
-        this.orderState = OrderState.CANCELLED;
+        if(OrderItemState.SHIPPED.equals(orderItemState) || OrderItemState.DELIVERED.equals(orderItemState)){
+            throw new RuntimeException("OrderItem is already " + orderItemState.name());
+        }
+
+        this.orderItemState = OrderItemState.CANCELLED;
     }
 
     public Long getTotalPrice(){

--- a/src/main/java/com/abc/mart/order/domain/OrderItemId.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderItemId.java
@@ -1,0 +1,17 @@
+package com.abc.mart.order.domain;
+
+import com.abc.mart.common.annotation.ValueObject;
+
+@ValueObject
+public record OrderItemId(
+        String id
+){
+
+    public static OrderItemId of(String id) {
+        return new OrderItemId(id);
+    }
+
+    public static OrderItemId generate(OrderId orderId,String productId, int sequence){
+        return new OrderItemId(orderId.id() +"-" + productId+"-"+sequence);
+    }
+}

--- a/src/main/java/com/abc/mart/order/domain/OrderItemState.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderItemState.java
@@ -1,0 +1,5 @@
+package com.abc.mart.order.domain;
+
+public enum OrderItemState {
+    PREPARING, SHIPPED, DELIVERED, RETURNED, CANCELLED
+}

--- a/src/main/java/com/abc/mart/order/domain/OrderState.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderState.java
@@ -1,5 +1,0 @@
-package com.abc.mart.order.domain;
-
-public enum OrderState {
-    PREPARING, SHIPPED, CANCELLED, COMPLETED
-}

--- a/src/main/java/com/abc/mart/order/domain/OrderStatus.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.abc.mart.order.domain;
+
+public enum OrderStatus {
+    REQUESTED, PAID, CANCELLED, COMPLETED
+}

--- a/src/main/java/com/abc/mart/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/abc/mart/order/domain/repository/OrderRepository.java
@@ -2,20 +2,23 @@ package com.abc.mart.order.domain.repository;
 
 import com.abc.mart.order.domain.Order;
 import com.abc.mart.order.domain.OrderId;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import com.abc.mart.order.domain.OrderItem;
+import com.abc.mart.order.domain.OrderItemId;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
-public interface OrderRepository extends JpaSpecificationExecutor<Order> {
+public interface OrderRepository{
 
     void placeOrder(Order order);
     Order findById(OrderId orderId);
+    OrderItem findById(OrderItemId orderItemId);
 
     //jpa를 아직 사용하지 않지만 spec 패턴 실습을 위해 사용
-    List<Order> findByTerm(Specification spec);
+    List<Order> findByTerm(LocalDateTime from, LocalDateTime to);
+    //List<Order> findByTerm(Specification spec);
 
     void save(Order order);
 }

--- a/src/main/java/com/abc/mart/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/abc/mart/order/domain/repository/OrderRepository.java
@@ -16,4 +16,6 @@ public interface OrderRepository extends JpaSpecificationExecutor<Order> {
 
     //jpa를 아직 사용하지 않지만 spec 패턴 실습을 위해 사용
     List<Order> findByTerm(Specification spec);
+
+    void save(Order order);
 }

--- a/src/main/java/com/abc/mart/order/domain/repository/OrderSpecification.java
+++ b/src/main/java/com/abc/mart/order/domain/repository/OrderSpecification.java
@@ -1,14 +1,15 @@
-package com.abc.mart.order.domain.repository;
-
-import com.abc.mart.order.domain.Order;
-import org.springframework.data.jpa.domain.Specification;
-
-import java.time.LocalDateTime;
-
-public class OrderSpecification {
-    public static Specification<Order> between(LocalDateTime from, LocalDateTime to) {
-        return (root, query, criteriaBuilder) ->
-                criteriaBuilder.between(root.get("createdDt"), from, to);
-
-    }
-}
+//package com.abc.mart.order.domain.repository;
+//
+//import com.abc.mart.order.domain.Order;
+//import org.springframework.data.jpa.domain.Specification;
+//
+//import java.time.LocalDateTime;
+//
+//public class OrderSpecification {
+//    public static Specification<Order> between(LocalDateTime from, LocalDateTime to) {
+//        return (root, query, criteriaBuilder) ->
+//                criteriaBuilder.between(root.get("createdDt"), from, to);
+//
+//    }
+//}
+//추후 jpa 연결 시 사용

--- a/src/main/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecase.java
@@ -1,7 +1,6 @@
 package com.abc.mart.order.usecase;
 
 import com.abc.mart.order.domain.repository.OrderRepository;
-import com.abc.mart.order.domain.repository.OrderSpecification;
 import com.abc.mart.order.usecase.dto.CalculateSalesRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,7 +12,7 @@ public class CalculateSalesAmountUsecase {
 
     @Transactional(readOnly = true)
     public long calculateSalesAmount(CalculateSalesRequest request) {
-        var orders = orderRepository.findByTerm(OrderSpecification.between(request.from(), request.to()));
+        var orders = orderRepository.findByTerm(request.from(), request.to());
 
         if (orders.isEmpty()) return 0;
 

--- a/src/main/java/com/abc/mart/order/usecase/CancelOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/CancelOrderUsecase.java
@@ -3,9 +3,9 @@ package com.abc.mart.order.usecase;
 import com.abc.mart.order.domain.Order;
 import com.abc.mart.order.domain.OrderId;
 import com.abc.mart.order.domain.repository.OrderRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
@@ -5,7 +5,10 @@ import com.abc.mart.order.domain.OrderId;
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.order.usecase.dto.PartialOrderCancelRequest;
 
+import com.abc.mart.payment.domain.PaymentHistory;
+import com.abc.mart.payment.domain.repository.PaymentHistoryRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,15 +17,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class PartialCancelOrderUsecase {
 
     private final OrderRepository orderRepository;
+    private final PaymentHistoryRepository paymentHistoryRepository;
 
     @Transactional
-    public Order cancelPartialOrder(PartialOrderCancelRequest request){
+    public Pair<Order, PaymentHistory> cancelPartialOrder(PartialOrderCancelRequest request){
         var order = orderRepository.findById(OrderId.of(request.orderId()));
-
         order.partialCancelOrder(request.cancelProductIds());
 
-        orderRepository.save(order);
+        var paymentHistory = paymentHistoryRepository.findByOrderId(OrderId.of(request.orderId()));
+        paymentHistory.cancelPartialPayment(request.partialPaymentCancelRequests());
 
-        return order;
+        orderRepository.save(order);
+        paymentHistoryRepository.save(paymentHistory);
+
+        return Pair.of(order, paymentHistory);
     }
 }

--- a/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
@@ -4,9 +4,10 @@ import com.abc.mart.order.domain.Order;
 import com.abc.mart.order.domain.OrderId;
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.order.usecase.dto.PartialOrderCancelRequest;
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
@@ -20,6 +20,8 @@ public class PartialCancelOrderUsecase {
 
         order.partialCancelOrder(request.cancelProductIds());
 
+        orderRepository.save(order);
+
         return order;
     }
 }

--- a/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
@@ -32,13 +32,15 @@ public class PlaceOrderUsecase {
 
         var productMap = productRepository.findByProductId(productIds).stream().collect(Collectors.toMap(Product::getId, p -> p));
 
+        var order = Order.createOrder(customer);
+
         var orderItems = orderRequest.orderItemRequestList().stream().map(orderItemRequest -> {
             var product = productMap.get(orderItemRequest.productId());
             var quantity = orderItemRequest.quantity();
-            return OrderItem.of(product, quantity);
+            return OrderItem.of(product, quantity, order.getOrderId(), orderItemRequest.sequence());
         }).toList();
 
-        var order = Order.createOrder(orderItems, customer);
+        order.setOrderItems(orderItems);
 
         orderRepository.placeOrder(order);
 

--- a/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
@@ -3,7 +3,6 @@ package com.abc.mart.order.usecase;
 import com.abc.mart.member.domain.repository.MemberRepository;
 import com.abc.mart.order.domain.Customer;
 import com.abc.mart.order.domain.Order;
-import com.abc.mart.order.domain.OrderItem;
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.order.domain.repository.ProductRepository;
 import com.abc.mart.order.usecase.dto.OrderRequest;
@@ -33,15 +32,7 @@ public class PlaceOrderUsecase {
 
         var productMap = productRepository.findByProductId(productIds).stream().collect(Collectors.toMap(Product::getId, p -> p));
 
-        var order = Order.createOrder(customer);
-
-        var orderItems = orderRequest.orderItemRequestList().stream().map(orderItemRequest -> {
-            var product = productMap.get(orderItemRequest.productId());
-            var quantity = orderItemRequest.quantity();
-            return OrderItem.of(product, quantity, order.getOrderId(), orderItemRequest.sequence());
-        }).toList();
-
-        order.setOrderItems(orderItems);
+        var order = Order.createOrder(customer, productMap, orderRequest.orderItemRequestList());
 
         orderRepository.placeOrder(order);
 

--- a/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
@@ -8,9 +8,10 @@ import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.order.domain.repository.ProductRepository;
 import com.abc.mart.order.usecase.dto.OrderRequest;
 import com.abc.mart.product.domain.Product;
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/abc/mart/order/usecase/dto/OrderRequest.java
+++ b/src/main/java/com/abc/mart/order/usecase/dto/OrderRequest.java
@@ -13,7 +13,8 @@ public record OrderRequest(
     @Builder
     public record OrderItemRequest(
             String productId,
-            int quantity
+            int quantity,
+            int sequence
     ){
 
     }

--- a/src/main/java/com/abc/mart/order/usecase/dto/PartialOrderCancelRequest.java
+++ b/src/main/java/com/abc/mart/order/usecase/dto/PartialOrderCancelRequest.java
@@ -1,5 +1,6 @@
 package com.abc.mart.order.usecase.dto;
 
+import com.abc.mart.payment.infra.PaymentMethodType;
 import lombok.Builder;
 
 import java.util.List;
@@ -7,6 +8,14 @@ import java.util.List;
 @Builder
 public record PartialOrderCancelRequest(
         String orderId,
-        List<String> cancelProductIds
+        List<String> cancelProductIds,
+        List<PartialPaymentCancelRequest> partialPaymentCancelRequests
 ) {
+    @Builder
+    public record PartialPaymentCancelRequest(
+            PaymentMethodType paymentMethodType,
+            Long cancelledAmountByPaymentMethod
+    ){
+
+    }
 }

--- a/src/main/java/com/abc/mart/payment/domain/PaymentDetail.java
+++ b/src/main/java/com/abc/mart/payment/domain/PaymentDetail.java
@@ -12,13 +12,20 @@ import lombok.experimental.FieldDefaults;
 public class PaymentDetail {
 
     PaymentMethodType paymentMethodType;
-    long totalPayedAmount;
+    long payedAmountByMethod;
 
     public static PaymentDetail create(PaymentMethodType paymentMethodType, long totalPayedAmount) {
         PaymentDetail paymentDetail = new PaymentDetail();
         paymentDetail.paymentMethodType = paymentMethodType;
-        paymentDetail.totalPayedAmount = totalPayedAmount;
+        paymentDetail.payedAmountByMethod = totalPayedAmount;
         return paymentDetail;
     }
 
+
+    public void partialCancelPayment(long partialCancelledAmount) {
+        if (partialCancelledAmount > payedAmountByMethod) {
+            throw new RuntimeException("Partial cancelled amount is greater than payed amount");
+        }
+        this.payedAmountByMethod -= partialCancelledAmount;
+    }
 }

--- a/src/main/java/com/abc/mart/payment/domain/PaymentDetail.java
+++ b/src/main/java/com/abc/mart/payment/domain/PaymentDetail.java
@@ -1,0 +1,23 @@
+package com.abc.mart.payment.domain;
+
+import com.abc.mart.common.annotation.ValueObject;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+
+@ValueObject
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Getter
+public class PaymentDetail {
+
+    PaymentMethod paymentMethod;
+    long totalPayedAmount;
+
+    public static PaymentDetail create(PaymentMethod paymentMethod, long totalPayedAmount) {
+        PaymentDetail paymentDetail = new PaymentDetail();
+        paymentDetail.paymentMethod = paymentMethod;
+        paymentDetail.totalPayedAmount = totalPayedAmount;
+        return paymentDetail;
+    }
+
+}

--- a/src/main/java/com/abc/mart/payment/domain/PaymentDetail.java
+++ b/src/main/java/com/abc/mart/payment/domain/PaymentDetail.java
@@ -1,6 +1,7 @@
 package com.abc.mart.payment.domain;
 
 import com.abc.mart.common.annotation.ValueObject;
+import com.abc.mart.payment.infra.PaymentMethodType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
@@ -10,12 +11,12 @@ import lombok.experimental.FieldDefaults;
 @Getter
 public class PaymentDetail {
 
-    PaymentMethod paymentMethod;
+    PaymentMethodType paymentMethodType;
     long totalPayedAmount;
 
-    public static PaymentDetail create(PaymentMethod paymentMethod, long totalPayedAmount) {
+    public static PaymentDetail create(PaymentMethodType paymentMethodType, long totalPayedAmount) {
         PaymentDetail paymentDetail = new PaymentDetail();
-        paymentDetail.paymentMethod = paymentMethod;
+        paymentDetail.paymentMethodType = paymentMethodType;
         paymentDetail.totalPayedAmount = totalPayedAmount;
         return paymentDetail;
     }

--- a/src/main/java/com/abc/mart/payment/domain/PaymentHistory.java
+++ b/src/main/java/com/abc/mart/payment/domain/PaymentHistory.java
@@ -1,0 +1,44 @@
+package com.abc.mart.payment.domain;
+
+import com.abc.mart.common.annotation.AggregateRoot;
+import com.abc.mart.order.domain.OrderId;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@AggregateRoot
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Getter
+public class PaymentHistory {
+    PaymentHistoryId id;
+    OrderId orderId;
+    List<PaymentDetail> paymentDetails;
+    long totalPayedAmount;
+    PaymentProcessState processState;
+    LocalDateTime createdDt;
+    LocalDateTime updatedDt;
+
+    public static PaymentHistory create(OrderId orderId, long totalPayedAmount,
+                                 List<PaymentDetail> paymentDetails, LocalDateTime createdDt) {
+
+        if (paymentDetails.stream().mapToLong(PaymentDetail::getTotalPayedAmount).sum() != totalPayedAmount) {
+            throw new RuntimeException("Payment total amount does not match");
+        }
+
+
+        PaymentHistory paymentHistory = new PaymentHistory();
+        paymentHistory.id = PaymentHistoryId.generate(orderId);
+        paymentHistory.orderId = orderId;
+        paymentHistory.paymentDetails = paymentDetails;
+        paymentHistory.totalPayedAmount = totalPayedAmount;
+        paymentHistory.createdDt = createdDt;
+        paymentHistory.updatedDt = createdDt;
+
+        return paymentHistory;
+    }
+
+}

--- a/src/main/java/com/abc/mart/payment/domain/PaymentHistoryId.java
+++ b/src/main/java/com/abc/mart/payment/domain/PaymentHistoryId.java
@@ -1,0 +1,18 @@
+package com.abc.mart.payment.domain;
+
+import com.abc.mart.common.annotation.ValueObject;
+import com.abc.mart.order.domain.OrderId;
+
+@ValueObject
+public record PaymentHistoryId(
+        String id
+){
+
+    public static PaymentHistoryId of(String id) {
+        return new PaymentHistoryId(id);
+    }
+
+    public static PaymentHistoryId generate(OrderId orderId){
+        return new PaymentHistoryId(orderId+"-paymentHistory");
+    }
+}

--- a/src/main/java/com/abc/mart/payment/domain/PaymentMethod.java
+++ b/src/main/java/com/abc/mart/payment/domain/PaymentMethod.java
@@ -1,0 +1,10 @@
+package com.abc.mart.payment.domain;
+
+import com.abc.mart.payment.infra.PaymentMethodType;
+
+public interface PaymentMethod {
+
+    PaymentMethodType getPaymentMethodType();
+    PaymentProcessState process(long paymentAmount);
+
+}

--- a/src/main/java/com/abc/mart/payment/domain/PaymentMethod.java
+++ b/src/main/java/com/abc/mart/payment/domain/PaymentMethod.java
@@ -6,5 +6,6 @@ public interface PaymentMethod {
 
     PaymentMethodType getPaymentMethodType();
     PaymentProcessState process(long paymentAmount);
+    PaymentProcessState cancel(long cancelledAmount);
 
 }

--- a/src/main/java/com/abc/mart/payment/domain/PaymentProcessState.java
+++ b/src/main/java/com/abc/mart/payment/domain/PaymentProcessState.java
@@ -1,0 +1,6 @@
+package com.abc.mart.payment.domain;
+
+public enum PaymentProcessState {
+    REQUESTED, FAILED, APPROVED, UNEXPECTED_FAILURE
+    //더 많아질 수 있지만 우선 간소히..
+}

--- a/src/main/java/com/abc/mart/payment/domain/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/abc/mart/payment/domain/repository/PaymentHistoryRepository.java
@@ -1,0 +1,9 @@
+package com.abc.mart.payment.domain.repository;
+
+import com.abc.mart.payment.domain.PaymentHistory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentHistoryRepository {
+    void save(PaymentHistory paymentHistory);
+}

--- a/src/main/java/com/abc/mart/payment/domain/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/abc/mart/payment/domain/repository/PaymentHistoryRepository.java
@@ -1,9 +1,11 @@
 package com.abc.mart.payment.domain.repository;
 
+import com.abc.mart.order.domain.OrderId;
 import com.abc.mart.payment.domain.PaymentHistory;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PaymentHistoryRepository {
     void save(PaymentHistory paymentHistory);
+    PaymentHistory findByOrderId(OrderId orderId);
 }

--- a/src/main/java/com/abc/mart/payment/infra/AmexCardPaymentMethod.java
+++ b/src/main/java/com/abc/mart/payment/infra/AmexCardPaymentMethod.java
@@ -1,0 +1,40 @@
+package com.abc.mart.payment.infra;
+
+import com.abc.mart.payment.domain.PaymentMethod;
+import com.abc.mart.payment.domain.PaymentProcessState;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import static com.abc.mart.payment.infra.AmexCardPaymentMethod.AmexCardProcessState.AMEX_CARD_PROCESSING_FINISHED;
+
+@Slf4j
+@Component
+public class AmexCardPaymentMethod implements PaymentMethod {
+
+    @Override
+    public PaymentMethodType getPaymentMethodType() {
+        return PaymentMethodType.AMEX_CARD;
+    }
+
+    @Override
+    public PaymentProcessState process(long paymentAmount) {
+        log.info("processing cash payment method : {}", paymentAmount);
+
+        return switch(callAmexCardApi()){
+            //외부 카드사 api에서 사용하는 상태값을 우리가 사용하는 상태값으로 치환하는 프로세스
+            case AMEX_CARD_PROCESSING_FINISHED -> PaymentProcessState.APPROVED;
+            case AMEX_CARD_PROCESSING_FAILED -> PaymentProcessState.FAILED;
+        };
+    }
+
+
+    public AmexCardProcessState callAmexCardApi(){
+        log.info("call amex card api");
+
+        return AMEX_CARD_PROCESSING_FINISHED;
+    }
+
+    enum AmexCardProcessState {
+        AMEX_CARD_PROCESSING_FAILED, AMEX_CARD_PROCESSING_FINISHED
+    }
+}

--- a/src/main/java/com/abc/mart/payment/infra/AmexCardPaymentMethod.java
+++ b/src/main/java/com/abc/mart/payment/infra/AmexCardPaymentMethod.java
@@ -18,10 +18,20 @@ public class AmexCardPaymentMethod implements PaymentMethod {
 
     @Override
     public PaymentProcessState process(long paymentAmount) {
-        log.info("processing cash payment method : {}", paymentAmount);
+        log.info("processing amex payment method : {}", paymentAmount);
 
         return switch(callAmexCardApi()){
             //외부 카드사 api에서 사용하는 상태값을 우리가 사용하는 상태값으로 치환하는 프로세스
+            case AMEX_CARD_PROCESSING_FINISHED -> PaymentProcessState.APPROVED;
+            case AMEX_CARD_PROCESSING_FAILED -> PaymentProcessState.FAILED;
+        };
+    }
+
+    @Override
+    public PaymentProcessState cancel(long cancelledAmount) {
+        log.info("cancel amex payment method : {}", cancelledAmount);
+
+        return switch(callAmexCardApi()){
             case AMEX_CARD_PROCESSING_FINISHED -> PaymentProcessState.APPROVED;
             case AMEX_CARD_PROCESSING_FAILED -> PaymentProcessState.FAILED;
         };

--- a/src/main/java/com/abc/mart/payment/infra/CashPaymentMethod.java
+++ b/src/main/java/com/abc/mart/payment/infra/CashPaymentMethod.java
@@ -1,0 +1,23 @@
+package com.abc.mart.payment.infra;
+
+import com.abc.mart.payment.domain.PaymentMethod;
+import com.abc.mart.payment.domain.PaymentProcessState;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CashPaymentMethod implements PaymentMethod {
+
+    @Override
+    public PaymentMethodType getPaymentMethodType() {
+        return PaymentMethodType.CASH;
+    }
+
+    @Override
+    public PaymentProcessState process(long paymentAmount) {
+        log.info("processing cash payment method : {}", paymentAmount);
+      return PaymentProcessState.APPROVED;
+    }
+
+}

--- a/src/main/java/com/abc/mart/payment/infra/CashPaymentMethod.java
+++ b/src/main/java/com/abc/mart/payment/infra/CashPaymentMethod.java
@@ -20,4 +20,10 @@ public class CashPaymentMethod implements PaymentMethod {
       return PaymentProcessState.APPROVED;
     }
 
+    @Override
+    public PaymentProcessState cancel(long cancelledAmount) {
+        log.info("cancel cash payment method : {}", cancelledAmount);
+        return PaymentProcessState.APPROVED;
+    }
+
 }

--- a/src/main/java/com/abc/mart/payment/infra/PaymentMethodRegistry.java
+++ b/src/main/java/com/abc/mart/payment/infra/PaymentMethodRegistry.java
@@ -1,0 +1,28 @@
+package com.abc.mart.payment.infra;
+
+import com.abc.mart.payment.domain.PaymentMethod;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+//전략 패턴 활용하여 PaymentMethod들의 구현체를 동적으로 구현하고, 필요한 구현체를 꺼내 쓸 수 있도록 함
+@Component
+public class PaymentMethodRegistry {
+    private final Map<PaymentMethodType, PaymentMethod> registry = new EnumMap<>(PaymentMethodType.class);
+
+    public PaymentMethodRegistry(List<PaymentMethod> paymentMethods) {
+        for (PaymentMethod method : paymentMethods) {
+            registry.put(method.getPaymentMethodType(), method);
+        }
+    }
+
+    public PaymentMethod getPaymentMethod(PaymentMethodType type) {
+        PaymentMethod method = registry.get(type);
+        if (method == null) {
+            throw new IllegalArgumentException("Unsupported payment method: " + type);
+        }
+        return method;
+    }
+}

--- a/src/main/java/com/abc/mart/payment/infra/PaymentMethodRegistry.java
+++ b/src/main/java/com/abc/mart/payment/infra/PaymentMethodRegistry.java
@@ -7,7 +7,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
-//전략 패턴 활용하여 PaymentMethod들의 구현체를 동적으로 구현하고, 필요한 구현체를 꺼내 쓸 수 있도록 함
+//전략 패턴 활용하여 PaymentMethod들의 구현체를 동적으로 등록하고, 필요한 구현체를 꺼내 쓸 수 있도록 함
 @Component
 public class PaymentMethodRegistry {
     private final Map<PaymentMethodType, PaymentMethod> registry = new EnumMap<>(PaymentMethodType.class);

--- a/src/main/java/com/abc/mart/payment/infra/PaymentMethodType.java
+++ b/src/main/java/com/abc/mart/payment/infra/PaymentMethodType.java
@@ -1,0 +1,5 @@
+package com.abc.mart.payment.infra;
+
+public enum PaymentMethodType {
+    CASH, VISA_CARD, AMEX_CARD
+}

--- a/src/main/java/com/abc/mart/payment/infra/VisaCardPaymentMethod.java
+++ b/src/main/java/com/abc/mart/payment/infra/VisaCardPaymentMethod.java
@@ -1,0 +1,39 @@
+package com.abc.mart.payment.infra;
+
+import com.abc.mart.payment.domain.PaymentMethod;
+import com.abc.mart.payment.domain.PaymentProcessState;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import static com.abc.mart.payment.infra.VisaCardPaymentMethod.VisaCardPaymentProcessState.VISA_CARD_PAYMENT_SUCCESS;
+
+@Slf4j
+@Component
+public class VisaCardPaymentMethod implements PaymentMethod {
+
+    @Override
+    public PaymentMethodType getPaymentMethodType() {
+        return PaymentMethodType.VISA_CARD;
+    }
+
+    @Override
+    public PaymentProcessState process(long paymentAmount) {
+        log.info("processing cash payment method : {}", paymentAmount);
+
+        return switch(callVisaCardApi()){
+            //외부 카드사 api에서 사용하는 상태값을 우리가 사용하는 상태값으로 치환하는 프로세스
+            case VISA_CARD_PAYMENT_SUCCESS -> PaymentProcessState.APPROVED;
+            case VISA_CARD_PAYMENT_FAILURE -> PaymentProcessState.FAILED;
+        };
+    }
+
+
+    public VisaCardPaymentProcessState callVisaCardApi(){
+        log.info("call visa card api");
+        return VISA_CARD_PAYMENT_SUCCESS;
+    }
+
+    enum VisaCardPaymentProcessState {
+        VISA_CARD_PAYMENT_FAILURE, VISA_CARD_PAYMENT_SUCCESS
+    }
+}

--- a/src/main/java/com/abc/mart/payment/infra/VisaCardPaymentMethod.java
+++ b/src/main/java/com/abc/mart/payment/infra/VisaCardPaymentMethod.java
@@ -18,10 +18,19 @@ public class VisaCardPaymentMethod implements PaymentMethod {
 
     @Override
     public PaymentProcessState process(long paymentAmount) {
-        log.info("processing cash payment method : {}", paymentAmount);
+        log.info("processing visa payment method : {}", paymentAmount);
 
         return switch(callVisaCardApi()){
             //외부 카드사 api에서 사용하는 상태값을 우리가 사용하는 상태값으로 치환하는 프로세스
+            case VISA_CARD_PAYMENT_SUCCESS -> PaymentProcessState.APPROVED;
+            case VISA_CARD_PAYMENT_FAILURE -> PaymentProcessState.FAILED;
+        };
+    }
+
+    @Override
+    public PaymentProcessState cancel(long cancelledAmount) {
+        log.info("cancel visa payment method : {}", cancelledAmount);
+        return switch(callVisaCardApi()){
             case VISA_CARD_PAYMENT_SUCCESS -> PaymentProcessState.APPROVED;
             case VISA_CARD_PAYMENT_FAILURE -> PaymentProcessState.FAILED;
         };

--- a/src/main/java/com/abc/mart/payment/usecase/ProcessPaymentUsecase.java
+++ b/src/main/java/com/abc/mart/payment/usecase/ProcessPaymentUsecase.java
@@ -1,0 +1,60 @@
+package com.abc.mart.payment.usecase;
+
+import com.abc.mart.order.domain.OrderId;
+import com.abc.mart.order.domain.OrderStatus;
+import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.payment.domain.PaymentDetail;
+import com.abc.mart.payment.domain.PaymentHistory;
+import com.abc.mart.payment.domain.PaymentProcessState;
+import com.abc.mart.payment.domain.repository.PaymentHistoryRepository;
+import com.abc.mart.payment.infra.PaymentMethodRegistry;
+import com.abc.mart.payment.usecase.dto.PaymentRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@RequiredArgsConstructor
+@Service
+public class ProcessPaymentUsecase {
+
+    private final PaymentMethodRegistry paymentMethodRegistry;
+    private final OrderRepository orderRepository;
+    private final PaymentHistoryRepository paymentHistoryRepository;
+
+    @Transactional
+    public PaymentHistory processPayment(PaymentRequest paymentRequest) {
+
+        var orderId = OrderId.of(paymentRequest.orderItemId());
+        var order = orderRepository.findById(orderId);
+
+        if(!OrderStatus.REQUESTED.equals(order.getOrderStatus())){
+            throw new RuntimeException("Order status should be PAYMENT_REQUESTED");
+        }
+
+        if (order.calculateTotalPrice() != paymentRequest.calculateTotalRequestedPaymentAmount()) {
+            throw new IllegalArgumentException("The requested payment amount does not meet the order amount.");
+        }
+
+        var processedPaymentDetails = paymentRequest.paymentDetailRequests().stream().map(paymentDetailRequest -> {
+            var selectedPaymentMethod = paymentMethodRegistry.getPaymentMethod(paymentDetailRequest.paymentMethodType());
+            var status = selectedPaymentMethod.process(paymentDetailRequest.payedAmount());
+
+            if (!PaymentProcessState.APPROVED.equals(status)) {
+                throw new RuntimeException("Payment processing failed by payment method " + paymentDetailRequest.paymentMethodType());
+            }
+
+            return PaymentDetail.create(selectedPaymentMethod, paymentDetailRequest.payedAmount());
+        }).toList();
+
+
+        var paymentHistory = PaymentHistory.create(orderId, paymentRequest.calculateTotalRequestedPaymentAmount(),
+                processedPaymentDetails, LocalDateTime.now(ZoneId.systemDefault()));
+        paymentHistoryRepository.save(paymentHistory);
+
+        return paymentHistory;
+
+    }
+}

--- a/src/main/java/com/abc/mart/payment/usecase/ProcessPaymentUsecase.java
+++ b/src/main/java/com/abc/mart/payment/usecase/ProcessPaymentUsecase.java
@@ -46,13 +46,16 @@ public class ProcessPaymentUsecase {
                 throw new RuntimeException("Payment processing failed by payment method " + paymentDetailRequest.paymentMethodType());
             }
 
-            return PaymentDetail.create(selectedPaymentMethod, paymentDetailRequest.payedAmount());
+            return PaymentDetail.create(paymentDetailRequest.paymentMethodType(), paymentDetailRequest.payedAmount());
         }).toList();
 
 
         var paymentHistory = PaymentHistory.create(orderId, paymentRequest.calculateTotalRequestedPaymentAmount(),
                 processedPaymentDetails, LocalDateTime.now(ZoneId.systemDefault()));
         paymentHistoryRepository.save(paymentHistory);
+
+        order.orderGetPaid();
+        orderRepository.save(order);
 
         return paymentHistory;
 

--- a/src/main/java/com/abc/mart/payment/usecase/dto/PaymentRequest.java
+++ b/src/main/java/com/abc/mart/payment/usecase/dto/PaymentRequest.java
@@ -1,0 +1,23 @@
+package com.abc.mart.payment.usecase.dto;
+
+
+import com.abc.mart.payment.infra.PaymentMethodType;
+
+import java.util.List;
+
+public record PaymentRequest(
+        String orderItemId,
+        List<PaymentDetailRequest> paymentDetailRequests
+) {
+
+    public long calculateTotalRequestedPaymentAmount(){
+        return paymentDetailRequests.stream().mapToLong(PaymentDetailRequest::payedAmount).sum();
+    }
+
+    public record PaymentDetailRequest(
+            PaymentMethodType paymentMethodType,
+            long payedAmount
+    ){
+
+    }
+}

--- a/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
@@ -33,16 +33,21 @@ class CalculateSalesAmountUsecaseTest {
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
-        var order1 = Order.createOrder(
-                List.of(OrderItem.of(products.getFirst(), 10), OrderItem.of(products.getLast(), 3)), customer
-        );
-        var order2 = Order.createOrder(
-                List.of(OrderItem.of(products.getFirst(), 7), OrderItem.of(products.getLast(), 2)), customer
-        );
+        var order1 = Order.createOrder(customer);
+        order1.setOrderItems(List.of(OrderItem.of(products.getFirst(), 10, order1.getOrderId(), 1),
+                OrderItem.of(products.getLast(), 3, order1.getOrderId(), 2)));
 
-        var order3 = Order.createOrder(
-                List.of(OrderItem.of(products.getFirst(), 6), OrderItem.of(products.getLast(), 2)), customer
-        );
+        var order2 = Order.createOrder(customer);
+        order2.setOrderItems(List.of(
+                OrderItem.of(products.getFirst(), 7, order2.getOrderId(), 1),
+                OrderItem.of(products.getLast(), 2, order2.getOrderId(), 2)
+        ));
+
+        var order3 = Order.createOrder(customer);
+        order3.setOrderItems(List.of(
+                OrderItem.of(products.getFirst(), 6, order3.getOrderId(), 1),
+                OrderItem.of(products.getLast(), 2, order3.getOrderId(), 2)
+        ));
 
         var from = LocalDateTime.now().minusMonths(1);
         var to = LocalDateTime.now();

--- a/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
@@ -52,7 +52,7 @@ class CalculateSalesAmountUsecaseTest {
         var from = LocalDateTime.now().minusMonths(1);
         var to = LocalDateTime.now();
 
-        when(orderRepository.findByTerm(any())).thenReturn(List.of(order1, order2, order3));
+        when(orderRepository.findByTerm(any(), any())).thenReturn(List.of(order1, order2, order3));
 
 
         //when

--- a/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
@@ -4,12 +4,14 @@ import com.abc.mart.member.domain.Member;
 import com.abc.mart.order.domain.*;
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.order.usecase.dto.CalculateSalesRequest;
+import com.abc.mart.order.usecase.dto.OrderRequest;
 import com.abc.mart.product.domain.Product;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,21 +35,25 @@ class CalculateSalesAmountUsecaseTest {
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
-        var order1 = Order.createOrder(customer);
-        order1.setOrderItems(List.of(OrderItem.of(products.getFirst(), 10, order1.getOrderId(), 1),
-                OrderItem.of(products.getLast(), 3, order1.getOrderId(), 2)));
+        var productMap = products.stream().collect(Collectors.toMap(Product::getId, p -> p));
 
-        var order2 = Order.createOrder(customer);
-        order2.setOrderItems(List.of(
-                OrderItem.of(products.getFirst(), 7, order2.getOrderId(), 1),
-                OrderItem.of(products.getLast(), 2, order2.getOrderId(), 2)
-        ));
+        var orderItemRequests1 = List.of(
+                new OrderRequest.OrderItemRequest(productId1, 10, 1),
+                new OrderRequest.OrderItemRequest(productId2, 3, 2)
+        );
+        var order1 = Order.createOrder(customer, productMap, orderItemRequests1);
 
-        var order3 = Order.createOrder(customer);
-        order3.setOrderItems(List.of(
-                OrderItem.of(products.getFirst(), 6, order3.getOrderId(), 1),
-                OrderItem.of(products.getLast(), 2, order3.getOrderId(), 2)
-        ));
+        var orderItemRequests2 = List.of(
+                new OrderRequest.OrderItemRequest(productId1, 7, 1),
+                new OrderRequest.OrderItemRequest(productId2, 2, 2)
+        );
+        var order2 = Order.createOrder(customer, productMap, orderItemRequests2);
+
+        var orderItemRequests3 = List.of(
+                new OrderRequest.OrderItemRequest(productId1, 6, 1),
+                new OrderRequest.OrderItemRequest(productId2, 2, 2)
+        );
+        var order3 = Order.createOrder(customer, productMap, orderItemRequests3);
 
         var from = LocalDateTime.now().minusMonths(1);
         var to = LocalDateTime.now();

--- a/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
@@ -3,7 +3,6 @@ package com.abc.mart.order.usecase;
 import com.abc.mart.member.domain.Member;
 import com.abc.mart.order.domain.*;
 import com.abc.mart.order.domain.repository.OrderRepository;
-import com.abc.mart.order.usecase.dto.PartialOrderCancelRequest;
 import com.abc.mart.product.domain.Product;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -45,8 +44,9 @@ class CancelOrderUsecaseTest {
         var res = usecase.cancelOrder(orderId.id());
 
         //then
-        assertEquals(OrderState.CANCELLED, res.getOrderItems().get(productId1).getOrderState());
-        assertEquals(OrderState.CANCELLED, res.getOrderItems().get(productId2).getOrderState());
+        assertEquals(OrderItemState.CANCELLED, res.getOrderItems().get(productId1).getOrderItemState());
+        assertEquals(OrderItemState.CANCELLED, res.getOrderItems().get(productId2).getOrderItemState());
+        assertEquals(OrderStatus.CANCELLED, res.getOrderStatus());
     }
 
 }

--- a/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
@@ -3,12 +3,14 @@ package com.abc.mart.order.usecase;
 import com.abc.mart.member.domain.Member;
 import com.abc.mart.order.domain.*;
 import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.order.usecase.dto.OrderRequest;
 import com.abc.mart.product.domain.Product;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
@@ -31,9 +33,14 @@ class CancelOrderUsecaseTest {
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
-        var order = Order.createOrder(customer);
-        order.setOrderItems(List.of(OrderItem.of(products.getFirst(), 10, order.getOrderId(), 1),
-                OrderItem.of(products.getLast(), 3, order.getOrderId(), 2)));
+        var productMap = products.stream().collect(Collectors.toMap(Product::getId, p -> p));
+
+        var orderItemRequests = List.of(
+                new OrderRequest.OrderItemRequest(products.get(0).getId(), 10, 1),
+                new OrderRequest.OrderItemRequest(products.get(1).getId(), 3, 2)
+        );
+
+        var order = Order.createOrder(customer, productMap, orderItemRequests);
 
         var now = LocalDateTime.now();
         var orderId = OrderId.generate(orderMemberId, now);

--- a/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
@@ -32,9 +32,9 @@ class CancelOrderUsecaseTest {
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
-        var order = Order.createOrder(
-                List.of(OrderItem.of(products.getFirst(), 10), OrderItem.of(products.getLast(), 3)), customer
-        );
+        var order = Order.createOrder(customer);
+        order.setOrderItems(List.of(OrderItem.of(products.getFirst(), 10, order.getOrderId(), 1),
+                OrderItem.of(products.getLast(), 3, order.getOrderId(), 2)));
 
         var now = LocalDateTime.now();
         var orderId = OrderId.generate(orderMemberId, now);

--- a/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
@@ -3,7 +3,6 @@ package com.abc.mart.order.usecase;
 import com.abc.mart.member.domain.Member;
 import com.abc.mart.order.domain.*;
 import com.abc.mart.order.domain.repository.OrderRepository;
-import com.abc.mart.order.usecase.dto.OrderRequest;
 import com.abc.mart.order.usecase.dto.PartialOrderCancelRequest;
 import com.abc.mart.product.domain.Product;
 import org.junit.jupiter.api.Test;
@@ -48,8 +47,8 @@ class PartialCancelOrderUsecaseTest {
         var res = usecase.cancelPartialOrder(partialCancelRequest);
 
         //then
-        assertEquals(OrderState.CANCELLED, res.getOrderItems().get(productId1).getOrderState());
-        assertEquals(OrderState.PREPARING, res.getOrderItems().get(productId2).getOrderState());
+        assertEquals(OrderItemState.CANCELLED, res.getOrderItems().get(productId1).getOrderItemState());
+        assertEquals(OrderItemState.PREPARING, res.getOrderItems().get(productId2).getOrderItemState());
     }
 
 }

--- a/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
@@ -3,13 +3,19 @@ package com.abc.mart.order.usecase;
 import com.abc.mart.member.domain.Member;
 import com.abc.mart.order.domain.*;
 import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.order.usecase.dto.OrderRequest;
 import com.abc.mart.order.usecase.dto.PartialOrderCancelRequest;
+import com.abc.mart.payment.domain.PaymentDetail;
+import com.abc.mart.payment.domain.PaymentHistory;
+import com.abc.mart.payment.domain.repository.PaymentHistoryRepository;
+import com.abc.mart.payment.infra.PaymentMethodType;
 import com.abc.mart.product.domain.Product;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
@@ -17,7 +23,8 @@ import static org.mockito.Mockito.when;
 class PartialCancelOrderUsecaseTest {
 
     OrderRepository orderRepository = Mockito.mock(OrderRepository.class);
-    PartialCancelOrderUsecase usecase = new PartialCancelOrderUsecase(orderRepository);
+    PaymentHistoryRepository paymentHistoryRepository = Mockito.mock(PaymentHistoryRepository.class);
+    PartialCancelOrderUsecase usecase = new PartialCancelOrderUsecase(orderRepository, paymentHistoryRepository);
 
     @Test
     void cancelPartialOrder() {
@@ -32,23 +39,51 @@ class PartialCancelOrderUsecaseTest {
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
-        var order = Order.createOrder(customer);
-        order.setOrderItems(List.of(OrderItem.of(products.getFirst(), 10, order.getOrderId(), 1),
-                OrderItem.of(products.getLast(), 3, order.getOrderId(), 2)));
+        var productMap = products.stream().collect(Collectors.toMap(Product::getId, p -> p));
+
+        var orderItemRequests = List.of(
+                new OrderRequest.OrderItemRequest(products.get(0).getId(), 10, 1),
+                new OrderRequest.OrderItemRequest(products.get(1).getId(), 3, 2)
+        );
+
+        var order = Order.createOrder(customer, productMap, orderItemRequests);
 
         var now = LocalDateTime.now();
         var orderId = OrderId.generate(orderMemberId, now);
         when(orderRepository.findById(orderId)).thenReturn(order);
 
+        var paymentHistory = PaymentHistory.create(orderId, 160000, List.of(
+                PaymentDetail.create(PaymentMethodType.CASH, 100000),
+                PaymentDetail.create(PaymentMethodType.VISA_CARD, 60000)
+        ), LocalDateTime.now());
 
-        var partialCancelRequest = PartialOrderCancelRequest.builder().orderId(orderId.id()).cancelProductIds(List.of(productId1)).build();
+        when(paymentHistoryRepository.findByOrderId(orderId)).thenReturn(paymentHistory);
+
+
+        var partialCancelRequest = PartialOrderCancelRequest.builder().orderId(orderId.id()).cancelProductIds(List.of(productId1))
+                .partialPaymentCancelRequests(List.of(
+                        PartialOrderCancelRequest.PartialPaymentCancelRequest.builder()
+                                .cancelledAmountByPaymentMethod(40000L)
+                                .paymentMethodType(PaymentMethodType.CASH)
+                                .build(),
+                        PartialOrderCancelRequest.PartialPaymentCancelRequest.builder()
+                                .cancelledAmountByPaymentMethod(60000L)
+                                .paymentMethodType(PaymentMethodType.VISA_CARD)
+                                .build()
+                )).build();
 
         //when
         var res = usecase.cancelPartialOrder(partialCancelRequest);
 
         //then
-        assertEquals(OrderItemState.CANCELLED, res.getOrderItems().get(productId1).getOrderItemState());
-        assertEquals(OrderItemState.PREPARING, res.getOrderItems().get(productId2).getOrderItemState());
+        var resOrder = res.getLeft();
+        var resPaymentHistory = res.getRight();
+        assertEquals(OrderItemState.CANCELLED, resOrder.getOrderItems().get(productId1).getOrderItemState());
+        assertEquals(OrderItemState.PREPARING, resOrder.getOrderItems().get(productId2).getOrderItemState());
+        assertEquals(60000, resOrder.calculateTotalPrice());
+        assertEquals(60000, resPaymentHistory.getTotalPayedAmount());
+        assertEquals(60000L, resPaymentHistory.getPaymentDetails().get(PaymentMethodType.CASH).getPayedAmountByMethod());
+        assertEquals(0L, resPaymentHistory.getPaymentDetails().get(PaymentMethodType.VISA_CARD).getPayedAmountByMethod());
     }
 
 }

--- a/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
@@ -33,9 +33,9 @@ class PartialCancelOrderUsecaseTest {
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
-        var order = Order.createOrder(
-                List.of(OrderItem.of(products.getFirst(), 10), OrderItem.of(products.getLast(), 3)), customer
-        );
+        var order = Order.createOrder(customer);
+        order.setOrderItems(List.of(OrderItem.of(products.getFirst(), 10, order.getOrderId(), 1),
+                OrderItem.of(products.getLast(), 3, order.getOrderId(), 2)));
 
         var now = LocalDateTime.now();
         var orderId = OrderId.generate(orderMemberId, now);

--- a/src/test/java/com/abc/mart/order/usecase/PlaceOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PlaceOrderUsecaseTest.java
@@ -2,7 +2,7 @@ package com.abc.mart.order.usecase;
 
 import com.abc.mart.member.domain.Member;
 import com.abc.mart.member.domain.repository.MemberRepository;
-import com.abc.mart.order.domain.OrderState;
+import com.abc.mart.order.domain.OrderItemState;
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.order.domain.repository.ProductRepository;
 import com.abc.mart.order.usecase.dto.OrderRequest;
@@ -53,8 +53,8 @@ class PlaceOrderUsecaseTest {
 
         //then
         assertEquals(70000, result.calculateTotalPrice());
-        assertEquals(OrderState.PREPARING, result.getOrderItems().get(productId1).getOrderState());
-        assertEquals(OrderState.PREPARING, result.getOrderItems().get(productId2).getOrderState());
+        assertEquals(OrderItemState.PREPARING, result.getOrderItems().get(productId1).getOrderItemState());
+        assertEquals(OrderItemState.PREPARING, result.getOrderItems().get(productId2).getOrderItemState());
         assertEquals(10000, result.getOrderItems().get(productId1).getTotalPrice());
         assertEquals(60000, result.getOrderItems().get(productId2).getTotalPrice());
     }

--- a/src/test/java/com/abc/mart/payment/usecase/ProcessPaymentUsecaseTest.java
+++ b/src/test/java/com/abc/mart/payment/usecase/ProcessPaymentUsecaseTest.java
@@ -1,0 +1,144 @@
+package com.abc.mart.payment.usecase;
+
+import com.abc.mart.order.domain.Order;
+import com.abc.mart.order.domain.OrderId;
+import com.abc.mart.order.domain.OrderStatus;
+import com.abc.mart.order.domain.repository.OrderRepository;
+import com.abc.mart.payment.domain.PaymentHistory;
+import com.abc.mart.payment.domain.PaymentMethod;
+import com.abc.mart.payment.domain.PaymentProcessState;
+import com.abc.mart.payment.domain.repository.PaymentHistoryRepository;
+import com.abc.mart.payment.infra.*;
+import com.abc.mart.payment.usecase.dto.PaymentRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ProcessPaymentUsecaseTest {
+
+    @Mock
+    private PaymentMethodRegistry paymentMethodRegistry;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private PaymentHistoryRepository paymentHistoryRepository;
+
+    @InjectMocks
+    private ProcessPaymentUsecase usecase;
+
+    private PaymentMethod cashPaymentMethod;
+    private PaymentMethod visaCardPaymentMethod;
+    private PaymentMethod amexCardPaymentMethod;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        cashPaymentMethod = mock(CashPaymentMethod.class);
+        visaCardPaymentMethod = mock(VisaCardPaymentMethod.class);
+        amexCardPaymentMethod = mock(AmexCardPaymentMethod.class);
+
+        when(paymentMethodRegistry.getPaymentMethod(PaymentMethodType.CASH)).thenReturn(cashPaymentMethod);
+        when(paymentMethodRegistry.getPaymentMethod(PaymentMethodType.VISA_CARD)).thenReturn(visaCardPaymentMethod);
+    }
+
+    @Test
+    void processPayment_Success() {
+        // given
+        var orderId = OrderId.generate("memberId", LocalDateTime.now());
+        var order = mock(Order.class);
+        when(orderRepository.findById(orderId)).thenReturn(order);
+        when(order.getOrderStatus()).thenReturn(OrderStatus.REQUESTED);
+        when(order.calculateTotalPrice()).thenReturn(30000L);
+
+        when(cashPaymentMethod.process(10000L)).thenReturn(PaymentProcessState.APPROVED);
+        when(visaCardPaymentMethod.process(20000L)).thenReturn(PaymentProcessState.APPROVED);
+
+        var paymentRequest = new PaymentRequest(
+                orderId.id(),
+                List.of(
+                        new PaymentRequest.PaymentDetailRequest(PaymentMethodType.CASH, 10000L),
+                        new PaymentRequest.PaymentDetailRequest(PaymentMethodType.VISA_CARD, 20000L)
+                )
+        );
+
+        // when
+        var paymentHistory = usecase.processPayment(paymentRequest);
+
+        // then
+        assertNotNull(paymentHistory);
+        assertEquals(30000L, paymentHistory.getTotalPayedAmount());
+        assertEquals(2, paymentHistory.getPaymentDetails().size());
+        verify(paymentHistoryRepository).save(any(PaymentHistory.class));
+        verify(paymentMethodRegistry).getPaymentMethod(PaymentMethodType.CASH);
+        verify(paymentMethodRegistry).getPaymentMethod(PaymentMethodType.VISA_CARD);
+    }
+
+    @Test
+    void processPayment_Failure_InvalidOrderStatus() {
+        // given
+        var orderId = OrderId.generate("memberId", LocalDateTime.now());
+        var order = mock(Order.class);
+        when(orderRepository.findById(orderId)).thenReturn(order);
+        when(order.getOrderStatus()).thenReturn(OrderStatus.CANCELLED);
+
+        var paymentRequest = new PaymentRequest(
+                orderId.id(),
+                List.of(new PaymentRequest.PaymentDetailRequest(PaymentMethodType.CASH, 10000L))
+        );
+
+        // when & then
+        var exception = assertThrows(RuntimeException.class, () -> usecase.processPayment(paymentRequest));
+        assertEquals("Order status should be PAYMENT_REQUESTED", exception.getMessage());
+    }
+
+    @Test
+    void processPayment_Failure_InvalidPaymentAmount() {
+        // given
+        var orderId = OrderId.generate("memberId", LocalDateTime.now());
+        var order = mock(Order.class);
+        when(orderRepository.findById(orderId)).thenReturn(order);
+        when(order.getOrderStatus()).thenReturn(OrderStatus.REQUESTED);
+        when(order.calculateTotalPrice()).thenReturn(30000L);
+
+        var paymentRequest = new PaymentRequest(
+                orderId.id(),
+                List.of(new PaymentRequest.PaymentDetailRequest(PaymentMethodType.CASH, 20000L))
+        );
+
+        // when & then
+        var exception = assertThrows(IllegalArgumentException.class, () -> usecase.processPayment(paymentRequest));
+        assertEquals("The requested payment amount does not meet the order amount.", exception.getMessage());
+    }
+
+    @Test
+    void processPayment_Failure_PaymentMethodDeclined() {
+        // given
+        var orderId = OrderId.generate("memberId", LocalDateTime.now());
+        var order = mock(Order.class);
+        when(orderRepository.findById(orderId)).thenReturn(order);
+        when(order.getOrderStatus()).thenReturn(OrderStatus.REQUESTED);
+        when(order.calculateTotalPrice()).thenReturn(30000L);
+
+        when(cashPaymentMethod.process(30000L)).thenReturn(PaymentProcessState.FAILED);
+
+        var paymentRequest = new PaymentRequest(
+                orderId.id(),
+                List.of(new PaymentRequest.PaymentDetailRequest(PaymentMethodType.CASH, 30000L))
+        );
+
+        // when & then
+        var exception = assertThrows(RuntimeException.class, () -> usecase.processPayment(paymentRequest));
+        assertEquals("Payment processing failed by payment method CASH", exception.getMessage());
+    }
+}


### PR DESCRIPTION
[📣 변경 사항]

orderItem은 vo -> entity로 변경 
- reason : 각각 품목별로 상태 변경이 일어날 수 있음, 결국 불변해야 한다는 vo의 규칙에 위배함.

order생성 이후에 orderItem생성하도록 변경
- reason : entity가 되어버린 orderitem, id가 필요해짐 - orderItemId에 orderid 정보 내포하고싶음

기존에는 orderitem의 상태만 존재했었으나, 결제 시 흐름이 어색한 관계(보통 품목별로 결제를 따로 하지는 않음)로 orderItemStatus, orderstatus 분리.
- **Order**의 `state`는 "결제 상태"에 집중
- **OrderItem**의 `state`는 "배송 상태"에 집중

[🗺️ 도메인 설계 map]
<img width="863" alt="image" src="https://github.com/user-attachments/assets/71d1c524-b35c-4a4d-a7d5-590d2abfbc25" />

[2주차 기능 구현]
- 카드사/현금 결제  - PaymentMethod 및 구현체 확인
   - 전략 패턴 + registry 패턴 사용하여 다양한 결제 수단에 동적으로 대비할 수 있도록 함
- 결제+분할결제 기능 - ProcessPaymentUsecase

[♻️ 리팩토링 필요한 부분]
- Order 생성자를 팩토리 메소드로 추출하여 OrderItem 엔티티도 이 안에서 함께 생성할지?
- 지금 jpa가 없으니 SpringBootTest등을 활용한 통합 테스트에 한계가 있음, repository의 구현체도 전부 만들던가 jpa 구현해야할 듯
- 트랜잭션이나 상태변경 등에 크게 신경을 못쓴 것 같은데 Order-Payment context사이 흐름을 어떻게 관리할지 고민 필요함