### PR TITLE
[week 4] 쿠폰 할인 기능 추가

### DIFF
--- a/src/main/java/com/abc/mart/coupon/domain/Coupon.java
+++ b/src/main/java/com/abc/mart/coupon/domain/Coupon.java
@@ -1,0 +1,23 @@
+package com.abc.mart.coupon.domain;
+
+import com.abc.mart.coupon.domain.policy.CouponPolicy;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class Coupon {
+    private String id;
+    private String name;
+    private CouponType couponType;
+    private int discountRate;
+    private CouponPolicy couponPolicy;
+    private LocalDateTime expiredAt;
+
+    public static Coupon createStockCoupon(String id, String name, CouponType couponType,
+                                           int discountRate, CouponPolicy couponPolicy, LocalDateTime expiredAt) {
+        return new Coupon(id, name, couponType, discountRate, couponPolicy, expiredAt);
+    }
+}

--- a/src/main/java/com/abc/mart/coupon/domain/CouponRepository.java
+++ b/src/main/java/com/abc/mart/coupon/domain/CouponRepository.java
@@ -1,0 +1,11 @@
+package com.abc.mart.coupon.domain;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CouponRepository {
+    List<Coupon> findStockCouponIssuedToMember(String memberId); //search for a stock coupon issued to a member
+    Coupon findHighestDiscountRateUniversalCouponsIssuedToMember(String memberId);
+}

--- a/src/main/java/com/abc/mart/coupon/domain/CouponRepository.java
+++ b/src/main/java/com/abc/mart/coupon/domain/CouponRepository.java
@@ -1,11 +1,14 @@
 package com.abc.mart.coupon.domain;
 
+import com.abc.mart.coupon.service.dto.StockCouponQueryDto;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface CouponRepository {
-    List<Coupon> findStockCouponIssuedToMember(String memberId); //search for a stock coupon issued to a member
+    List<StockCouponQueryDto> findStockCouponIssuedToMember(String memberId); //search for a stock coupon issued to a member
     Coupon findHighestDiscountRateUniversalCouponsIssuedToMember(String memberId);
+
+    List<MemberIssuedCoupon> findIssuedCouponsByCouponId(String couponId);
 }

--- a/src/main/java/com/abc/mart/coupon/domain/CouponType.java
+++ b/src/main/java/com/abc/mart/coupon/domain/CouponType.java
@@ -1,0 +1,6 @@
+package com.abc.mart.coupon.domain;
+
+public enum CouponType {
+    STOCK_DISCOUNT,
+    UNIVERSAL_DISCOUNT
+}

--- a/src/main/java/com/abc/mart/coupon/domain/MemberIssuedCoupon.java
+++ b/src/main/java/com/abc/mart/coupon/domain/MemberIssuedCoupon.java
@@ -1,9 +1,15 @@
 package com.abc.mart.coupon.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.time.LocalDateTime;
 
+@Getter
+@AllArgsConstructor
 public class MemberIssuedCoupon {
-    String memberId;
-    String couponId;
-    LocalDateTime issuedAt;
+    private String memberId;
+    private String couponId;
+    private LocalDateTime issuedAt;
+    private boolean used;
 }

--- a/src/main/java/com/abc/mart/coupon/domain/MemberIssuedCoupon.java
+++ b/src/main/java/com/abc/mart/coupon/domain/MemberIssuedCoupon.java
@@ -1,0 +1,9 @@
+package com.abc.mart.coupon.domain;
+
+import java.time.LocalDateTime;
+
+public class MemberIssuedCoupon {
+    String memberId;
+    String couponId;
+    LocalDateTime issuedAt;
+}

--- a/src/main/java/com/abc/mart/coupon/domain/policy/CouponPolicy.java
+++ b/src/main/java/com/abc/mart/coupon/domain/policy/CouponPolicy.java
@@ -1,0 +1,7 @@
+package com.abc.mart.coupon.domain.policy;
+
+import com.abc.mart.coupon.domain.CouponType;
+
+public sealed interface CouponPolicy permits UniversalCouponPolicy, StockCouponPolicy {
+    CouponType getCouponType(); // Returns the type of coupon this policy applies to
+}

--- a/src/main/java/com/abc/mart/coupon/domain/policy/StockCouponPolicy.java
+++ b/src/main/java/com/abc/mart/coupon/domain/policy/StockCouponPolicy.java
@@ -1,0 +1,25 @@
+package com.abc.mart.coupon.domain.policy;
+
+import com.abc.mart.coupon.domain.CouponType;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+//StockCouponPolicy is available after a certain number of days since the product was stocked
+@AllArgsConstructor
+public final class StockCouponPolicy implements CouponPolicy {
+    private int availableAfterStockedDays;
+
+    public boolean isEligibleForCoupon(LocalDateTime stockedDateTime) {
+        LocalDateTime now = LocalDateTime.now();
+        long daysElapsed = ChronoUnit.DAYS.between(stockedDateTime, now);
+        // Check if the number of days elapsed since the stocked date is greater than or equal to the availableAfterStockedDays
+        return daysElapsed >= availableAfterStockedDays;
+    }
+
+    @Override
+    public CouponType getCouponType() {
+        return CouponType.STOCK_DISCOUNT;
+    }
+}

--- a/src/main/java/com/abc/mart/coupon/domain/policy/UniversalCouponPolicy.java
+++ b/src/main/java/com/abc/mart/coupon/domain/policy/UniversalCouponPolicy.java
@@ -1,0 +1,12 @@
+package com.abc.mart.coupon.domain.policy;
+
+import com.abc.mart.coupon.domain.CouponType;
+
+public final class UniversalCouponPolicy implements CouponPolicy {
+    @Override
+    public CouponType getCouponType() {
+        return CouponType.UNIVERSAL_DISCOUNT;
+    }
+    //This class doesn't have any fields or methods yet, but it can be extended in the future
+    //Universal is applied for total amount of purchase
+}

--- a/src/main/java/com/abc/mart/coupon/service/CouponService.java
+++ b/src/main/java/com/abc/mart/coupon/service/CouponService.java
@@ -2,7 +2,8 @@ package com.abc.mart.coupon.service;
 
 import com.abc.mart.coupon.domain.Coupon;
 import com.abc.mart.coupon.domain.CouponRepository;
-import com.abc.mart.coupon.domain.policy.StockCouponPolicy;
+import com.abc.mart.coupon.domain.MemberIssuedCoupon;
+import com.abc.mart.coupon.service.dto.StockCouponQueryDto;
 import com.abc.mart.product.Stock;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,18 +20,18 @@ public class CouponService {
         // 2. If yes, apply the coupon to the stock
         // 3. Return the discounted price
 
-        List<Coupon> coupons = couponRepository.findStockCouponIssuedToMember(memberId);
+        List<StockCouponQueryDto> coupons = couponRepository.findStockCouponIssuedToMember(memberId);
 
         if (coupons == null) return 0L;
 
         return stocks.stream().mapToLong(
                 stock -> coupons.stream()
-                            .filter(c -> c.getCouponPolicy() instanceof StockCouponPolicy stockPolicy
-                                    && stockPolicy.isEligibleForCoupon(stock.getLoadedAt()))
-                            .mapToInt(Coupon::getDiscountRate)//if several coupons are applicable, take the maximum discount rate
+                            .filter(s-> s.stockCouponPolicy().isEligibleForCoupon(stock.getLoadedAt()))
+                            .mapToInt(StockCouponQueryDto::discountRate)//if several coupons are applicable, take the maximum discount rate
                             .max()
                             .orElse(0)
         ).map(maxRate -> (productPrice * maxRate) / 100).sum();
+        //TODO 쿠폰 사용됐으면 사용 처리 필요
     }
 
     public long applyUniversalCouponAndReturnDiscountedAmount(String memberId, long currentPrice) {
@@ -40,5 +41,10 @@ public class CouponService {
         if (coupon == null) return 0L;
 
         return currentPrice * (long) coupon.getDiscountRate() / 100;
+    }
+
+    public long countUsedQuantityByEachCoupon(String couponId){
+        List<MemberIssuedCoupon> issuedCoupons = couponRepository.findIssuedCouponsByCouponId(couponId);
+        return issuedCoupons.stream().filter(MemberIssuedCoupon::isUsed).count();
     }
 }

--- a/src/main/java/com/abc/mart/coupon/service/CouponService.java
+++ b/src/main/java/com/abc/mart/coupon/service/CouponService.java
@@ -1,0 +1,44 @@
+package com.abc.mart.coupon.service;
+
+import com.abc.mart.coupon.domain.Coupon;
+import com.abc.mart.coupon.domain.CouponRepository;
+import com.abc.mart.coupon.domain.policy.StockCouponPolicy;
+import com.abc.mart.product.Stock;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class CouponService {
+    private final CouponRepository couponRepository;
+
+    public long applyStockCouponAndReturnDiscountedAmount(String memberId, List<Stock> stocks, long productPrice) {
+        // 1. Check if the member has a seller coupon issued
+        // 2. If yes, apply the coupon to the stock
+        // 3. Return the discounted price
+
+        List<Coupon> coupons = couponRepository.findStockCouponIssuedToMember(memberId);
+
+        if (coupons == null) return 0L;
+
+        return stocks.stream().mapToLong(
+                stock -> coupons.stream()
+                            .filter(c -> c.getCouponPolicy() instanceof StockCouponPolicy stockPolicy
+                                    && stockPolicy.isEligibleForCoupon(stock.getLoadedAt()))
+                            .mapToInt(Coupon::getDiscountRate)//if several coupons are applicable, take the maximum discount rate
+                            .max()
+                            .orElse(0)
+        ).map(maxRate -> (productPrice * maxRate) / 100).sum();
+    }
+
+    public long applyUniversalCouponAndReturnDiscountedAmount(String memberId, long currentPrice) {
+
+        Coupon coupon = couponRepository.findHighestDiscountRateUniversalCouponsIssuedToMember(memberId);
+
+        if (coupon == null) return 0L;
+
+        return currentPrice * (long) coupon.getDiscountRate() / 100;
+    }
+}

--- a/src/main/java/com/abc/mart/coupon/service/dto/StockCouponQueryDto.java
+++ b/src/main/java/com/abc/mart/coupon/service/dto/StockCouponQueryDto.java
@@ -1,0 +1,12 @@
+package com.abc.mart.coupon.service.dto;
+
+import com.abc.mart.coupon.domain.policy.StockCouponPolicy;
+import lombok.Getter;
+
+public record StockCouponQueryDto (
+        String memberIssuedCouponId,
+        StockCouponPolicy stockCouponPolicy,
+        int discountRate
+){
+
+}

--- a/src/main/java/com/abc/mart/coupon/usecase/CouponAdminUsecase.java
+++ b/src/main/java/com/abc/mart/coupon/usecase/CouponAdminUsecase.java
@@ -1,0 +1,15 @@
+package com.abc.mart.coupon.usecase;
+
+import com.abc.mart.coupon.service.CouponService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouponAdminUsecase {
+    private final CouponService couponService;
+
+    public long countUsedQuantityByEachCoupon(String couponId){
+        return couponService.countUsedQuantityByEachCoupon(couponId);
+    }
+}

--- a/src/main/java/com/abc/mart/order/domain/CouponRedemptionHistory.java
+++ b/src/main/java/com/abc/mart/order/domain/CouponRedemptionHistory.java
@@ -1,0 +1,6 @@
+package com.abc.mart.order.domain;
+
+sealed public interface CouponRedemptionHistory
+        permits UniversalCouponRedemptionHistory, StockCouponRedemptionHistory {
+    long getDiscountedPrice();
+}

--- a/src/main/java/com/abc/mart/order/domain/Customer.java
+++ b/src/main/java/com/abc/mart/order/domain/Customer.java
@@ -3,10 +3,12 @@ package com.abc.mart.order.domain;
 import com.abc.mart.common.annotation.ValueObject;
 import com.abc.mart.member.domain.Member;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @ValueObject
 @AllArgsConstructor
 public class Customer {
+    @Getter
     String memberId;
     String name;
     String email;

--- a/src/main/java/com/abc/mart/order/domain/Order.java
+++ b/src/main/java/com/abc/mart/order/domain/Order.java
@@ -20,13 +20,14 @@ public class Order {
     private Map<String, OrderItem> orderItems;
     @Getter
     private OrderStatus orderStatus;
-    @Setter
-    private long universalDiscountPrice;
+
+    @Getter
+    private List<CouponRedemptionHistory> couponRedemptionHistories;
     private Customer customer;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static Order createOrder(List<OrderItem> orderItems, Customer customer, long universalDiscountPrice) {
+    public static Order createOrder(List<OrderItem> orderItems, Customer customer) {
         Order order = new Order();
         var now = LocalDateTime.now();
 
@@ -34,15 +35,20 @@ public class Order {
         order.orderId = id;
 
         order.setOrderItems(orderItems);
+
+        order.couponRedemptionHistories = new ArrayList<>();
         order.customer = customer;
 
         order.orderStatus = OrderStatus.REQUESTED;
-        order.universalDiscountPrice = universalDiscountPrice;
 
         order.createdAt = now;
         order.updatedAt = now;
 
         return order;
+    }
+
+    public void saveCouponRedemptionHistories(List<CouponRedemptionHistory> couponRedemptionHistories) {
+        this.couponRedemptionHistories.addAll(couponRedemptionHistories);
     }
 
     public void setOrderItems(List<OrderItem> orderItems){
@@ -73,9 +79,13 @@ public class Order {
         return this.orderItems.get(productId).getTotalPrice();
     }
 
+    public long calculateTotalDiscountedAmount() {
+        return couponRedemptionHistories.stream().mapToLong(CouponRedemptionHistory::getDiscountedPrice).sum();
+    }
+
     public long calculateTotalPrice() {
         return this.orderItems.values().stream().mapToLong(OrderItem::getTotalPrice).sum()
-                - this.universalDiscountPrice;
+                - calculateTotalDiscountedAmount();
     }
 
     public void orderGetPaid() {

--- a/src/main/java/com/abc/mart/order/domain/Order.java
+++ b/src/main/java/com/abc/mart/order/domain/Order.java
@@ -17,6 +17,8 @@ public class Order {
 
     @Getter
     private Map<String, OrderItem> orderItems;
+    @Getter
+    private OrderStatus orderStatus;
     private Customer customer;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -30,6 +32,8 @@ public class Order {
 
         order.setOrderItems(orderItems);
         order.customer = customer;
+
+        order.orderStatus = OrderStatus.REQUESTED;
 
         order.createdAt = now;
         order.updatedAt = now;
@@ -49,6 +53,7 @@ public class Order {
         for(var orderItem : orderItems.values()){
             orderItem.cancelOrderItem();
         }
+        orderStatus = OrderStatus.CANCELLED;
     }
 
     public List<OrderItem> partialCancelOrder(List<String> cancelledItemIds) {
@@ -66,6 +71,10 @@ public class Order {
 
     public long calculateTotalPrice() {
         return this.orderItems.values().stream().mapToLong(OrderItem::getTotalPrice).sum();
+    }
+
+    public void orderGetPaid() {
+        this.orderStatus = OrderStatus.PAID;
     }
 
 }

--- a/src/main/java/com/abc/mart/order/domain/Order.java
+++ b/src/main/java/com/abc/mart/order/domain/Order.java
@@ -2,6 +2,7 @@ package com.abc.mart.order.domain;
 
 import com.abc.mart.common.annotation.AggregateRoot;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -19,11 +20,13 @@ public class Order {
     private Map<String, OrderItem> orderItems;
     @Getter
     private OrderStatus orderStatus;
+    @Setter
+    private long universalDiscountPrice;
     private Customer customer;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static Order createOrder(List<OrderItem> orderItems, Customer customer) {
+    public static Order createOrder(List<OrderItem> orderItems, Customer customer, long universalDiscountPrice) {
         Order order = new Order();
         var now = LocalDateTime.now();
 
@@ -34,6 +37,7 @@ public class Order {
         order.customer = customer;
 
         order.orderStatus = OrderStatus.REQUESTED;
+        order.universalDiscountPrice = universalDiscountPrice;
 
         order.createdAt = now;
         order.updatedAt = now;
@@ -70,7 +74,8 @@ public class Order {
     }
 
     public long calculateTotalPrice() {
-        return this.orderItems.values().stream().mapToLong(OrderItem::getTotalPrice).sum();
+        return this.orderItems.values().stream().mapToLong(OrderItem::getTotalPrice).sum()
+                - this.universalDiscountPrice;
     }
 
     public void orderGetPaid() {

--- a/src/main/java/com/abc/mart/order/domain/OrderItem.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderItem.java
@@ -5,6 +5,8 @@ import com.abc.mart.product.domain.Product;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @ValueObject
 //Has the same lifecycle with Order entity
 public class OrderItem {
@@ -17,6 +19,8 @@ public class OrderItem {
     private int quantity;
 
     @Getter
+    private List<String> stockIds;
+    @Getter
     private OrderItemState orderState;
 
     public static OrderItem of(Product product, int quantity){
@@ -27,6 +31,10 @@ public class OrderItem {
         orderItem.orderState = OrderItemState.PREPARING;
 
         return orderItem;
+    }
+
+    public void setStockIds(List<String> stockIds) {
+        this.stockIds = stockIds;
     }
 
     public void cancelOrderItem(){

--- a/src/main/java/com/abc/mart/order/domain/OrderItem.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderItem.java
@@ -17,20 +17,20 @@ public class OrderItem {
     private int quantity;
 
     @Getter
-    private OrderState orderState;
+    private OrderItemState orderState;
 
     public static OrderItem of(Product product, int quantity){
         var orderItem = new OrderItem();
         orderItem.productId = product.getId();
         orderItem.orderedPrice = product.getPrice();
         orderItem.quantity = quantity;
-        orderItem.orderState = OrderState.PREPARING;
+        orderItem.orderState = OrderItemState.PREPARING;
 
         return orderItem;
     }
 
     public void cancelOrderItem(){
-        this.orderState = OrderState.CANCELLED;
+        this.orderState = OrderItemState.CANCELLED;
     }
 
     public Long getTotalPrice(){

--- a/src/main/java/com/abc/mart/order/domain/OrderItem.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderItem.java
@@ -11,15 +11,16 @@ import java.util.List;
 //Has the same lifecycle with Order entity
 public class OrderItem {
 
+    @Getter
+    private String id;
+
     @Setter
     @Getter
     private String productId;
     @Getter
     private int quantity;
 
-    private long regularPrice;
-
-    private long stockDiscountedAmount;
+    private long orderedPrice;
 
     @Setter
     @Getter
@@ -27,11 +28,12 @@ public class OrderItem {
     @Getter
     private OrderItemState orderState;
 
-    public static OrderItem of(Product product, long regularPrice, int quantity){
+    public static OrderItem of(Product product, long orderedPrice, int quantity){
         var orderItem = new OrderItem();
+        orderItem.id = "orderitem" + product.getId() + System.currentTimeMillis();
         orderItem.productId = product.getId();
         orderItem.quantity = quantity;
-        orderItem.regularPrice = regularPrice;
+        orderItem.orderedPrice = orderedPrice;
         orderItem.orderState = OrderItemState.PREPARING;
         return orderItem;
     }
@@ -40,11 +42,7 @@ public class OrderItem {
         this.orderState = OrderItemState.CANCELLED;
     }
 
-    public void discounted(long amount){
-        stockDiscountedAmount = amount;
-    }
-
     public long getTotalPrice(){
-        return regularPrice * quantity - stockDiscountedAmount;
+        return orderedPrice * quantity;
     }
 }

--- a/src/main/java/com/abc/mart/order/domain/OrderItem.java
+++ b/src/main/java/com/abc/mart/order/domain/OrderItem.java
@@ -14,34 +14,37 @@ public class OrderItem {
     @Setter
     @Getter
     private String productId;
-    private Long orderedPrice; //snapshot of the price when the order was placed
     @Getter
     private int quantity;
 
+    private long regularPrice;
+
+    private long stockDiscountedAmount;
+
+    @Setter
     @Getter
     private List<String> stockIds;
     @Getter
     private OrderItemState orderState;
 
-    public static OrderItem of(Product product, int quantity){
+    public static OrderItem of(Product product, long regularPrice, int quantity){
         var orderItem = new OrderItem();
         orderItem.productId = product.getId();
-        orderItem.orderedPrice = product.getPrice();
         orderItem.quantity = quantity;
+        orderItem.regularPrice = regularPrice;
         orderItem.orderState = OrderItemState.PREPARING;
-
         return orderItem;
-    }
-
-    public void setStockIds(List<String> stockIds) {
-        this.stockIds = stockIds;
     }
 
     public void cancelOrderItem(){
         this.orderState = OrderItemState.CANCELLED;
     }
 
-    public Long getTotalPrice(){
-        return quantity * orderedPrice;
+    public void discounted(long amount){
+        stockDiscountedAmount = amount;
+    }
+
+    public long getTotalPrice(){
+        return regularPrice * quantity - stockDiscountedAmount;
     }
 }

--- a/src/main/java/com/abc/mart/order/domain/StockCouponRedemptionHistory.java
+++ b/src/main/java/com/abc/mart/order/domain/StockCouponRedemptionHistory.java
@@ -1,0 +1,20 @@
+package com.abc.mart.order.domain;
+
+public final class StockCouponRedemptionHistory implements CouponRedemptionHistory {
+
+        private long discountedPrice;
+        private String orderItemId;
+
+        public static CouponRedemptionHistory create(String orderItemId, long discountedPrice) {
+                StockCouponRedemptionHistory history = new StockCouponRedemptionHistory();
+                history.orderItemId = orderItemId;
+                history.discountedPrice = discountedPrice;
+                return history;
+        }
+
+        @Override
+        public long getDiscountedPrice() {
+                return discountedPrice;
+        }
+
+}

--- a/src/main/java/com/abc/mart/order/domain/UniversalCouponRedemptionHistory.java
+++ b/src/main/java/com/abc/mart/order/domain/UniversalCouponRedemptionHistory.java
@@ -1,0 +1,20 @@
+package com.abc.mart.order.domain;
+
+
+public final class UniversalCouponRedemptionHistory implements CouponRedemptionHistory {
+
+    private long discountedPrice;
+    private String orderId;
+
+    public static CouponRedemptionHistory create(long discountedPrice, String orderId){
+        UniversalCouponRedemptionHistory history = new UniversalCouponRedemptionHistory();
+        history.discountedPrice = discountedPrice;
+        history.orderId = orderId;
+        return history;
+    }
+
+    @Override
+    public long getDiscountedPrice() {
+        return discountedPrice;
+    }
+}

--- a/src/main/java/com/abc/mart/order/usecase/CancelOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/CancelOrderUsecase.java
@@ -26,9 +26,9 @@ public class CancelOrderUsecase {
         order.getOrderItems().forEach(((id, item) -> productRepository.findByProductIdAndIsAvailable(item.getProductId(), true)
                 .ifPresentOrElse(
                         p -> {
-                            var before = p.getStockCount();
-                            p.addStock(item.getQuantity());
-                            log.info("Product {} stock updated: {} -> {}", p.getId(), before, p.getStockCount());
+                            var before = p.getStocks();
+                            p.restoreStock(item.getStockIds());
+                            log.info("Product {} stock updated: {} -> {}", p.getId(), before, p.getStocks());
                             productRepository.save(p);
                         },
                         () ->

--- a/src/main/java/com/abc/mart/order/usecase/CancelOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/CancelOrderUsecase.java
@@ -4,10 +4,10 @@ import com.abc.mart.order.domain.Order;
 import com.abc.mart.order.domain.OrderId;
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.product.domain.repository.ProductRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j

--- a/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
@@ -27,9 +27,9 @@ public class PartialCancelOrderUsecase {
         cancelledItems.forEach(item -> productRepository.findByProductIdAndIsAvailable(item.getProductId(), true)
                 .ifPresentOrElse(
                 p -> {
-                    var before = p.getStockCount();
-                    p.addStock(item.getQuantity());
-                    log.info("Product {} stock updated: {} -> {}", p.getId(), before, p.getStockCount());
+                    var before = p.getStocks();
+                    p.restoreStock(item.getStockIds());
+                    log.info("Product {} stock updated: {} -> {}", p.getId(), before, p.getStocks());
                     productRepository.save(p);
                 },
                 () ->

--- a/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PartialCancelOrderUsecase.java
@@ -5,10 +5,10 @@ import com.abc.mart.order.domain.OrderId;
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.product.domain.repository.ProductRepository;
 import com.abc.mart.order.usecase.dto.PartialOrderCancelRequest;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j

--- a/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
@@ -8,10 +8,10 @@ import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.product.domain.repository.ProductRepository;
 import com.abc.mart.order.usecase.dto.OrderRequest;
 import com.abc.mart.product.domain.Product;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
+++ b/src/main/java/com/abc/mart/order/usecase/PlaceOrderUsecase.java
@@ -43,18 +43,27 @@ public class PlaceOrderUsecase {
             }
 
             var quantity = orderItemRequest.quantity();
-            return OrderItem.of(product, quantity);
+
+            var orderItem = OrderItem.of(product, quantity);
+
+            var orderedProduct = productMap.get(orderItem.getProductId());
+            var soldStockIds = orderedProduct.subtractStock(orderItem.getQuantity());
+            orderItem.setStockIds(soldStockIds);
+
+            productRepository.save(orderedProduct);
+
+            return orderItem;
         }).toList();
 
         var order = Order.createOrder(orderItems, customer);
+
+
 
         orderRepository.placeOrder(order);
 
         orderItems.forEach(orderItem ->
         {
-            var orderedProduct = productMap.get(orderItem.getProductId());
-            orderedProduct.subtractStock(orderItem.getQuantity());
-            productRepository.save(orderedProduct);
+
         });
         return Pair.of(order, productMap);
     }

--- a/src/main/java/com/abc/mart/product/Stock.java
+++ b/src/main/java/com/abc/mart/product/Stock.java
@@ -1,0 +1,29 @@
+package com.abc.mart.product;
+
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+public class Stock {
+    private String id;
+    private LocalDateTime loadedAt;
+    private boolean sold;
+
+    public static Stock of(String id, LocalDateTime loadedAt) {
+        Stock stock = new Stock();
+        stock.id = id;
+        stock.loadedAt = loadedAt;
+        stock.sold = false;
+        return stock;
+    }
+
+
+    public void setUnsold() {
+        this.sold = false;
+    }
+
+    public void setSold() {
+        this.sold = true;
+    }
+
+}

--- a/src/main/java/com/abc/mart/product/domain/Product.java
+++ b/src/main/java/com/abc/mart/product/domain/Product.java
@@ -1,7 +1,11 @@
 package com.abc.mart.product.domain;
 
+import com.abc.mart.product.Stock;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.Comparator;
+import java.util.List;
 
 @AllArgsConstructor
 @Getter
@@ -10,22 +14,36 @@ public class Product {
     private String id;
     private String name;
     private long price;
-    private int stockCount;
+    private List<Stock> stocks;
     private boolean isAvaliable;
 
-    public static Product of(String id, String name, long price, int stockCount, boolean isOnSale) {
-        return new Product(id, name, price, stockCount, isOnSale);
+    public static Product of(String id, String name, long price, List<Stock> stocks, boolean isOnSale) {
+        return new Product(id, name, price, stocks, isOnSale);
     }
 
-    public void addStock(int quantity){
-        this.stockCount += quantity;
+    public void addStock(List<Stock> stocks){
+        this.stocks.addAll(stocks);
     }
 
-    public void subtractStock(int quantity){
-        if (this.stockCount < quantity) {
+    public void restoreStock(List<String> stockIds){
+        this.stocks.stream()
+                .filter(stock -> stockIds.contains(stock.getId()))
+                .forEach(Stock::setUnsold);
+    }
+
+    public List<String> subtractStock(int quantity){
+        if (this.stocks.size() < quantity) {
             throw new IllegalArgumentException("Insufficient stock");
         }
-        this.stockCount -= quantity;
+
+        return stocks.stream()
+                .filter(stock -> !stock.isSold())
+                .sorted(Comparator.comparing(Stock::getLoadedAt))
+                .limit(quantity)
+                .map(stock -> {
+                    stock.setSold();
+                    return stock.getId();
+                }).toList();
     }
 
     public void manageProductAvailability(boolean isAvailable) {

--- a/src/main/java/com/abc/mart/product/domain/Product.java
+++ b/src/main/java/com/abc/mart/product/domain/Product.java
@@ -31,7 +31,7 @@ public class Product {
                 .forEach(Stock::setUnsold);
     }
 
-    public List<String> subtractStock(int quantity){
+    public List<Stock> subtractStock(int quantity){
         if (this.stocks.size() < quantity) {
             throw new IllegalArgumentException("Insufficient stock");
         }
@@ -42,7 +42,7 @@ public class Product {
                 .limit(quantity)
                 .map(stock -> {
                     stock.setSold();
-                    return stock.getId();
+                    return stock;
                 }).toList();
     }
 

--- a/src/main/java/com/abc/mart/product/usecase/ProductManagementUsecase.java
+++ b/src/main/java/com/abc/mart/product/usecase/ProductManagementUsecase.java
@@ -1,10 +1,13 @@
 package com.abc.mart.product.usecase;
 
+import com.abc.mart.product.Stock;
 import com.abc.mart.product.domain.repository.ProductRepository;
+import com.abc.mart.product.usecase.dto.ReqStock;
 import com.abc.mart.product.usecase.dto.ResFetchStock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -27,15 +30,16 @@ public class ProductManagementUsecase {
         return products.stream().map(product -> new ResFetchStock(
                 product.getId(),
                 product.getName(),
-                product.getStockCount())).toList();
+                product.getStocks().size())).toList();
     }
 
     @Transactional
-    public void orderStock(String productId, int quantity){
+    public void orderStock(String productId, List<ReqStock> reqStocks){
         var product = productRepository.findByProductId(productId)
                 .orElseThrow(() -> new IllegalArgumentException("Product not found"));
 
-        product.addStock(quantity);
+        product.addStock(new ArrayList<>(reqStocks.stream().map(req ->
+                Stock.of(req.stockId(), req.loadedAt())).toList()));
         productRepository.save(product);
     }
 }

--- a/src/main/java/com/abc/mart/product/usecase/dto/ReqStock.java
+++ b/src/main/java/com/abc/mart/product/usecase/dto/ReqStock.java
@@ -1,0 +1,9 @@
+package com.abc.mart.product.usecase.dto;
+
+import java.time.LocalDateTime;
+
+public record ReqStock(
+        String stockId,
+        LocalDateTime loadedAt
+) {
+}

--- a/src/test/java/com/abc/mart/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/abc/mart/coupon/service/CouponServiceTest.java
@@ -1,0 +1,53 @@
+package com.abc.mart.coupon.service;
+
+import com.abc.mart.coupon.domain.Coupon;
+import com.abc.mart.coupon.domain.CouponRepository;
+import com.abc.mart.coupon.domain.CouponType;
+import com.abc.mart.coupon.domain.policy.StockCouponPolicy;
+import com.abc.mart.product.Stock;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class CouponServiceTest {
+
+    CouponRepository couponRepository = Mockito.mock(CouponRepository.class);
+    CouponService couponService = new CouponService(couponRepository);
+
+    @Test
+    void applyStockCouponAndReturnDiscountedAmount_WithStockCouponPolicy() {
+        // given
+        var memberId = "memberId";
+        var productPrice = 10000L;
+
+        // 30일 및 60일 기준의 StockCouponPolicy 생성
+        var stockPolicy30Days = new StockCouponPolicy(30);
+        var stockPolicy60Days = new StockCouponPolicy(60);
+
+        // 쿠폰 생성
+        var coupon1 = Coupon.createStockCoupon("coupon1", "30일 재고 쿠폰", CouponType.STOCK_DISCOUNT,
+                10, stockPolicy30Days, LocalDateTime.now()); // 10% 할인
+        var coupon2 = Coupon.createStockCoupon("coupon2", "60일 재고 쿠폰", CouponType.STOCK_DISCOUNT,
+                20, stockPolicy60Days, LocalDateTime.now()); // 20% 할인
+
+        // 재고 생성
+        var stocks = List.of(
+                Stock.of("1",LocalDateTime.now().minusDays(25)), // 30일 이내
+                Stock.of("2",LocalDateTime.now().minusDays(50)), // 60일 이내
+                Stock.of("3",LocalDateTime.now().minusDays(70))  // 60일 초과
+        );
+
+        when(couponRepository.findStockCouponIssuedToMember(memberId)).thenReturn(List.of(coupon1, coupon2));
+
+        // when
+        var result = couponService.applyStockCouponAndReturnDiscountedAmount(memberId, stocks, productPrice);
+
+        // then
+        assertEquals(3000L, result); // 10% + 20% 할인 적용
+    }
+}

--- a/src/test/java/com/abc/mart/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/abc/mart/coupon/service/CouponServiceTest.java
@@ -3,7 +3,9 @@ package com.abc.mart.coupon.service;
 import com.abc.mart.coupon.domain.Coupon;
 import com.abc.mart.coupon.domain.CouponRepository;
 import com.abc.mart.coupon.domain.CouponType;
+import com.abc.mart.coupon.domain.MemberIssuedCoupon;
 import com.abc.mart.coupon.domain.policy.StockCouponPolicy;
+import com.abc.mart.coupon.service.dto.StockCouponQueryDto;
 import com.abc.mart.product.Stock;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -30,16 +32,14 @@ class CouponServiceTest {
         var stockPolicy60Days = new StockCouponPolicy(60);
 
         // 쿠폰 생성
-        var coupon1 = Coupon.createStockCoupon("coupon1", "30일 재고 쿠폰", CouponType.STOCK_DISCOUNT,
-                10, stockPolicy30Days, LocalDateTime.now()); // 10% 할인
-        var coupon2 = Coupon.createStockCoupon("coupon2", "60일 재고 쿠폰", CouponType.STOCK_DISCOUNT,
-                20, stockPolicy60Days, LocalDateTime.now()); // 20% 할인
+        var coupon1 = new StockCouponQueryDto("coupon1", stockPolicy30Days, 10); // 10% 할인
+        var coupon2 = new StockCouponQueryDto("coupon2", stockPolicy60Days, 20); // 20% 할인
 
         // 재고 생성
         var stocks = List.of(
-                Stock.of("1",LocalDateTime.now().minusDays(25)), // 30일 이내
-                Stock.of("2",LocalDateTime.now().minusDays(50)), // 60일 이내
-                Stock.of("3",LocalDateTime.now().minusDays(70))  // 60일 초과
+                Stock.of("1", LocalDateTime.now().minusDays(25)), // 30일 이내
+                Stock.of("2", LocalDateTime.now().minusDays(50)), // 60일 이내
+                Stock.of("3", LocalDateTime.now().minusDays(70))  // 60일 초과
         );
 
         when(couponRepository.findStockCouponIssuedToMember(memberId)).thenReturn(List.of(coupon1, coupon2));
@@ -50,4 +50,26 @@ class CouponServiceTest {
         // then
         assertEquals(3000L, result); // 10% + 20% 할인 적용
     }
+
+    @Test
+    void countUsedQuantityByEachCoupon_ShouldReturnCorrectCount() {
+        // given
+        var couponId = "coupon123";
+
+        var issuedCoupons = List.of(
+                new MemberIssuedCoupon("member1", couponId, LocalDateTime.now(), true),
+                new MemberIssuedCoupon("member2", couponId, LocalDateTime.now(), false),
+                new MemberIssuedCoupon("member3", couponId, LocalDateTime.now(), true)
+        );
+
+        when(couponRepository.findIssuedCouponsByCouponId(couponId)).thenReturn(issuedCoupons);
+
+        // when
+        var result = couponService.countUsedQuantityByEachCoupon(couponId);
+
+        // then
+        assertEquals(2, result); // 사용된 쿠폰은 2개
+    }
+
+
 }

--- a/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
@@ -41,19 +41,19 @@ class CalculateSalesAmountUsecaseTest {
                 OrderItem.of(products.get(0), products.get(0).getPrice(), 10),
                 OrderItem.of(products.get(1), products.get(1).getPrice(), 3)
         );
-        var order1 = Order.createOrder(orderItems1, customer, 5000);
+        var order1 = Order.createOrder(orderItems1, customer);
 
         var orderItems2 = List.of(
                 OrderItem.of(products.get(0), products.get(0).getPrice(),7),
                 OrderItem.of(products.get(1), products.get(1).getPrice(),2)
         );
-        var order2 = Order.createOrder(orderItems2, customer, 7000);
+        var order2 = Order.createOrder(orderItems2, customer);
 
         var orderItems3 = List.of(
                 OrderItem.of(products.get(0), products.get(0).getPrice(),6),
                 OrderItem.of(products.get(1), products.get(1).getPrice(), 2)
         );
-        var order3 = Order.createOrder(orderItems3, customer, 5000);
+        var order3 = Order.createOrder(orderItems3, customer);
 
         var from = LocalDateTime.now().minusMonths(1);
         var to = LocalDateTime.now();

--- a/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
@@ -10,8 +10,8 @@ import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
+import static com.abc.mart.test.TestStubCreator.generateRandomStocks;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -31,8 +31,8 @@ class CalculateSalesAmountUsecaseTest {
 
         var orderMemberId = "memberId";
         var products = List.of(
-                Product.of(productId1, "productName1", price1, 10, true),
-                Product.of(productId2, "productName2", price2, 5, true)
+                Product.of(productId1, "productName1", price1, generateRandomStocks(10), true),
+                Product.of(productId2, "productName2", price2, generateRandomStocks(5), true)
         );
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));

--- a/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
@@ -4,7 +4,6 @@ import com.abc.mart.member.domain.Member;
 import com.abc.mart.order.domain.*;
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.order.usecase.dto.CalculateSalesRequest;
-import com.abc.mart.order.usecase.dto.OrderRequest;
 import com.abc.mart.product.domain.Product;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -13,7 +12,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -24,52 +23,50 @@ class CalculateSalesAmountUsecaseTest {
 
     @Test
     void CalculateSalesAmountUsecaseTest() {
-        //given
+        // given
         var productId1 = "productId1";
         var productId2 = "productId2";
         var price1 = 10000;
         var price2 = 20000;
 
         var orderMemberId = "memberId";
-        var products = List.of(Product.of(productId1, "productName", price1, 10, true), Product.of(productId2, "productName", price2, 5, true));
+        var products = List.of(
+                Product.of(productId1, "productName1", price1, 10, true),
+                Product.of(productId2, "productName2", price2, 5, true)
+        );
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
-        var productMap = products.stream().collect(Collectors.toMap(Product::getId, p -> p));
-
-        var orderItemRequests1 = List.of(
-                new OrderRequest.OrderItemRequest(productId1, 10, 1),
-                new OrderRequest.OrderItemRequest(productId2, 3, 2)
+        var orderItems1 = List.of(
+                OrderItem.of(products.get(0), 10),
+                OrderItem.of(products.get(1), 3)
         );
-        var order1 = Order.createOrder(customer, productMap, orderItemRequests1);
+        var order1 = Order.createOrder(orderItems1, customer);
 
-        var orderItemRequests2 = List.of(
-                new OrderRequest.OrderItemRequest(productId1, 7, 1),
-                new OrderRequest.OrderItemRequest(productId2, 2, 2)
+        var orderItems2 = List.of(
+                OrderItem.of(products.get(0), 7),
+                OrderItem.of(products.get(1), 2)
         );
-        var order2 = Order.createOrder(customer, productMap, orderItemRequests2);
+        var order2 = Order.createOrder(orderItems2, customer);
 
-        var orderItemRequests3 = List.of(
-                new OrderRequest.OrderItemRequest(productId1, 6, 1),
-                new OrderRequest.OrderItemRequest(productId2, 2, 2)
+        var orderItems3 = List.of(
+                OrderItem.of(products.get(0), 6),
+                OrderItem.of(products.get(1), 2)
         );
-        var order3 = Order.createOrder(customer, productMap, orderItemRequests3);
+        var order3 = Order.createOrder(orderItems3, customer);
 
         var from = LocalDateTime.now().minusMonths(1);
         var to = LocalDateTime.now();
 
         when(orderRepository.findByTerm(any(), any())).thenReturn(List.of(order1, order2, order3));
 
-
-        //when
+        // when
         var calculateSalesAmountRequest = CalculateSalesRequest.builder()
                 .productId(productId1).from(from).to(to).build();
 
         var res = calculateSalesAmountUsecase.calculateSalesAmount(calculateSalesAmountRequest);
 
-        //then
+        // then
         assertEquals(230000, res);
-
     }
-
 }

--- a/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CalculateSalesAmountUsecaseTest.java
@@ -38,22 +38,22 @@ class CalculateSalesAmountUsecaseTest {
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
         var orderItems1 = List.of(
-                OrderItem.of(products.get(0), 10),
-                OrderItem.of(products.get(1), 3)
+                OrderItem.of(products.get(0), products.get(0).getPrice(), 10),
+                OrderItem.of(products.get(1), products.get(1).getPrice(), 3)
         );
-        var order1 = Order.createOrder(orderItems1, customer);
+        var order1 = Order.createOrder(orderItems1, customer, 5000);
 
         var orderItems2 = List.of(
-                OrderItem.of(products.get(0), 7),
-                OrderItem.of(products.get(1), 2)
+                OrderItem.of(products.get(0), products.get(0).getPrice(),7),
+                OrderItem.of(products.get(1), products.get(1).getPrice(),2)
         );
-        var order2 = Order.createOrder(orderItems2, customer);
+        var order2 = Order.createOrder(orderItems2, customer, 7000);
 
         var orderItems3 = List.of(
-                OrderItem.of(products.get(0), 6),
-                OrderItem.of(products.get(1), 2)
+                OrderItem.of(products.get(0), products.get(0).getPrice(),6),
+                OrderItem.of(products.get(1), products.get(1).getPrice(), 2)
         );
-        var order3 = Order.createOrder(orderItems3, customer);
+        var order3 = Order.createOrder(orderItems3, customer, 5000);
 
         var from = LocalDateTime.now().minusMonths(1);
         var to = LocalDateTime.now();

--- a/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
@@ -41,14 +41,14 @@ class CancelOrderUsecaseTest {
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
-        var orderItem1 = OrderItem.of(products.get(0), 10);
+        var orderItem1 = OrderItem.of(products.get(0), 10000, 10);
         orderItem1.setStockIds(List.of("1","2", "3", "4", "5", "6", "7", "8", "9", "10"));
 
-        var orderItem2 = OrderItem.of(products.get(1), 5);
+        var orderItem2 = OrderItem.of(products.get(1), 20000,5);
         orderItem2.setStockIds(List.of("11","12","13","14","15"));
 
         var order = Order.createOrder(
-                List.of(orderItem1, orderItem2), customer
+                List.of(orderItem1, orderItem2), customer, 5000
         );
 
         var now = LocalDateTime.now();

--- a/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
@@ -48,7 +48,7 @@ class CancelOrderUsecaseTest {
         orderItem2.setStockIds(List.of("11","12","13","14","15"));
 
         var order = Order.createOrder(
-                List.of(orderItem1, orderItem2), customer, 5000
+                List.of(orderItem1, orderItem2), customer
         );
 
         var now = LocalDateTime.now();

--- a/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/CancelOrderUsecaseTest.java
@@ -53,8 +53,8 @@ class CancelOrderUsecaseTest {
 
         //then
         //재고 변경은 로그로 확인 가능
-        assertEquals(OrderState.CANCELLED, res.getOrderItems().get(productId1).getOrderState());
-        assertEquals(OrderState.CANCELLED, res.getOrderItems().get(productId2).getOrderState());
+        assertEquals(OrderItemState.CANCELLED, res.getOrderItems().get(productId1).getOrderState());
+        assertEquals(OrderItemState.CANCELLED, res.getOrderItems().get(productId2).getOrderState());
     }
 
 }

--- a/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
@@ -56,8 +56,8 @@ class PartialCancelOrderUsecaseTest {
 
         //then
         //재고 변경은 로그로 확인 가능
-        assertEquals(OrderState.CANCELLED, res.getOrderItems().get(productId1).getOrderState());
-        assertEquals(OrderState.PREPARING, res.getOrderItems().get(productId2).getOrderState());
+        assertEquals(OrderItemState.CANCELLED, res.getOrderItems().get(productId1).getOrderState());
+        assertEquals(OrderItemState.PREPARING, res.getOrderItems().get(productId2).getOrderState());
     }
 
 }

--- a/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
@@ -45,7 +45,7 @@ class PartialCancelOrderUsecaseTest {
         orderItem2.setStockIds(List.of("2","3","4"));
 
         var order = Order.createOrder(
-                List.of(orderItem1, orderItem2), customer, 5000
+                List.of(orderItem1, orderItem2), customer
         );
 
         var now = LocalDateTime.now();

--- a/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
@@ -3,7 +3,6 @@ package com.abc.mart.order.usecase;
 import com.abc.mart.member.domain.Member;
 import com.abc.mart.order.domain.*;
 import com.abc.mart.order.domain.repository.OrderRepository;
-import com.abc.mart.order.usecase.dto.OrderRequest;
 import com.abc.mart.order.usecase.dto.PartialOrderCancelRequest;
 import com.abc.mart.product.domain.Product;
 import com.abc.mart.product.domain.repository.ProductRepository;
@@ -14,9 +13,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.abc.mart.test.TestStubCreator.generateRandomStocks;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 class PartialCancelOrderUsecaseTest {
@@ -34,12 +32,20 @@ class PartialCancelOrderUsecaseTest {
         var price2 = 20000;
 
         var orderMemberId = "memberId";
-        var products = List.of(Product.of(productId1, "productName", price1, 10, true), Product.of(productId2, "productName", price2, 5, true));
+        var products = List.of(Product.of(productId1, "productName", price1,
+                        generateRandomStocks(10), true),
+                Product.of(productId2, "productName", price2, generateRandomStocks(5), true));
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
+        var orderItem1 = OrderItem.of(products.get(0), 10);
+        orderItem1.setStockIds(List.of("1","2", "3", "4", "5", "6", "7", "8", "9", "10"));
+
+        var orderItem2 = OrderItem.of(products.get(1), 3);
+        orderItem2.setStockIds(List.of("2","3","4"));
+
         var order = Order.createOrder(
-                List.of(OrderItem.of(products.getFirst(), 10), OrderItem.of(products.getLast(), 3)), customer
+                List.of(orderItem1, orderItem2), customer
         );
 
         var now = LocalDateTime.now();

--- a/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PartialCancelOrderUsecaseTest.java
@@ -38,14 +38,14 @@ class PartialCancelOrderUsecaseTest {
 
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
-        var orderItem1 = OrderItem.of(products.get(0), 10);
+        var orderItem1 = OrderItem.of(products.get(0), 10000, 10);
         orderItem1.setStockIds(List.of("1","2", "3", "4", "5", "6", "7", "8", "9", "10"));
 
-        var orderItem2 = OrderItem.of(products.get(1), 3);
+        var orderItem2 = OrderItem.of(products.get(1), 20000, 3);
         orderItem2.setStockIds(List.of("2","3","4"));
 
         var order = Order.createOrder(
-                List.of(orderItem1, orderItem2), customer
+                List.of(orderItem1, orderItem2), customer, 5000
         );
 
         var now = LocalDateTime.now();

--- a/src/test/java/com/abc/mart/order/usecase/PlaceOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PlaceOrderUsecaseTest.java
@@ -2,7 +2,7 @@ package com.abc.mart.order.usecase;
 
 import com.abc.mart.member.domain.Member;
 import com.abc.mart.member.domain.repository.MemberRepository;
-import com.abc.mart.order.domain.OrderState;
+import com.abc.mart.order.domain.OrderItemState;
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.product.domain.repository.ProductRepository;
 import com.abc.mart.order.usecase.dto.OrderRequest;
@@ -52,11 +52,11 @@ class PlaceOrderUsecaseTest {
         var result = placeOrderUsecase.placeOrder(orderRequest);
 
         //then
-        var resOrder = result.getFirst();
-        var resProducts = result.getSecond();
+        var resOrder = result.getLeft();
+        var resProducts = result.getRight();
         assertEquals(70000, resOrder.calculateTotalPrice());
-        assertEquals(OrderState.PREPARING, resOrder.getOrderItems().get(productId1).getOrderState());
-        assertEquals(OrderState.PREPARING, resOrder.getOrderItems().get(productId2).getOrderState());
+        assertEquals(OrderItemState.PREPARING, resOrder.getOrderItems().get(productId1).getOrderState());
+        assertEquals(OrderItemState.PREPARING, resOrder.getOrderItems().get(productId2).getOrderState());
         assertEquals(10000, resOrder.getOrderItems().get(productId1).getTotalPrice());
         assertEquals(60000, resOrder.getOrderItems().get(productId2).getTotalPrice());
         assertEquals(9, resProducts.get(productId1).getStockCount());

--- a/src/test/java/com/abc/mart/order/usecase/PlaceOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PlaceOrderUsecaseTest.java
@@ -4,6 +4,8 @@ import com.abc.mart.coupon.service.CouponService;
 import com.abc.mart.member.domain.Member;
 import com.abc.mart.member.domain.repository.MemberRepository;
 import com.abc.mart.order.domain.OrderItemState;
+import com.abc.mart.order.domain.StockCouponRedemptionHistory;
+import com.abc.mart.order.domain.UniversalCouponRedemptionHistory;
 import com.abc.mart.order.domain.repository.OrderRepository;
 import com.abc.mart.product.domain.repository.ProductRepository;
 import com.abc.mart.order.usecase.dto.OrderRequest;
@@ -15,6 +17,7 @@ import java.util.List;
 
 import static com.abc.mart.test.TestStubCreator.generateRandomStocks;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -66,10 +69,14 @@ class PlaceOrderUsecaseTest {
         var resOrder = result.getLeft();
         var resProducts = result.getRight();
         assertEquals(54000, resOrder.calculateTotalPrice());
+        assertEquals(16000, resOrder.calculateTotalDiscountedAmount());
         assertEquals(OrderItemState.PREPARING, resOrder.getOrderItems().get(productId1).getOrderState());
         assertEquals(OrderItemState.PREPARING, resOrder.getOrderItems().get(productId2).getOrderState());
-        assertEquals(5000, resOrder.getOrderItems().get(productId1).getTotalPrice());
-        assertEquals(55000, resOrder.getOrderItems().get(productId2).getTotalPrice());
+        assertEquals(10000, resOrder.getOrderItems().get(productId1).getTotalPrice());
+        assertEquals(60000, resOrder.getOrderItems().get(productId2).getTotalPrice());
+        assertEquals(3, resOrder.getCouponRedemptionHistories().size());
+        assertInstanceOf(StockCouponRedemptionHistory.class, resOrder.getCouponRedemptionHistories().getFirst());
+        assertInstanceOf(UniversalCouponRedemptionHistory.class, resOrder.getCouponRedemptionHistories().getLast());
         assertEquals(9, resProducts.get(productId1).getStocks().stream().filter(s -> !s.isSold()).toList().size());
         assertEquals(2, resProducts.get(productId2).getStocks().stream().filter(s -> !s.isSold()).toList().size());
     }

--- a/src/test/java/com/abc/mart/order/usecase/PlaceOrderUsecaseTest.java
+++ b/src/test/java/com/abc/mart/order/usecase/PlaceOrderUsecaseTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static com.abc.mart.test.TestStubCreator.generateRandomStocks;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,7 +44,8 @@ class PlaceOrderUsecaseTest {
 
         var member = Member.of(orderMemberId, "memberName", "email", "phoneNum");
         var productIds = List.of(productId1, productId2);
-        var products = List.of(Product.of(productId1, "productName", price1, 10, true), Product.of(productId2, "productName", price2, 5, true));
+        var products = List.of(Product.of(productId1, "productName", price1, generateRandomStocks(10), true), Product.of(productId2, "productName", price2,
+                generateRandomStocks(5), true));
 
         when(memberRepository.findByMemberId(orderMemberId)).thenReturn(member);
         when(productRepository.findAllByProductIdAndIsAvailable(productIds, true)).thenReturn(products);
@@ -59,8 +61,10 @@ class PlaceOrderUsecaseTest {
         assertEquals(OrderItemState.PREPARING, resOrder.getOrderItems().get(productId2).getOrderState());
         assertEquals(10000, resOrder.getOrderItems().get(productId1).getTotalPrice());
         assertEquals(60000, resOrder.getOrderItems().get(productId2).getTotalPrice());
-        assertEquals(9, resProducts.get(productId1).getStockCount());
-        assertEquals(2, resProducts.get(productId2).getStockCount());
+        assertEquals(9, resProducts.get(productId1).getStocks().stream().filter(s -> !s.isSold()).toList().size());
+        assertEquals(2, resProducts.get(productId2).getStocks().stream().filter(s -> !s.isSold()).toList().size());
     }
+
+
 
 }

--- a/src/test/java/com/abc/mart/payment/usecase/ProcessPaymentUsecaseTest.java
+++ b/src/test/java/com/abc/mart/payment/usecase/ProcessPaymentUsecaseTest.java
@@ -3,7 +3,6 @@ package com.abc.mart.payment.usecase;
 import com.abc.mart.member.domain.Member;
 import com.abc.mart.order.domain.*;
 import com.abc.mart.order.domain.repository.OrderRepository;
-import com.abc.mart.order.usecase.dto.OrderRequest;
 import com.abc.mart.payment.domain.PaymentHistory;
 import com.abc.mart.payment.domain.PaymentMethod;
 import com.abc.mart.payment.domain.PaymentProcessState;
@@ -21,6 +20,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.abc.mart.test.TestStubCreator.generateRandomStocks;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -65,7 +65,8 @@ class ProcessPaymentUsecaseTest {
         var price2 = 20000;
 
         var orderMemberId = "memberId";
-        var products = List.of(Product.of(productId1, "productName", price1, 10, true), Product.of(productId2, "productName", price2, 20, true));
+        var products = List.of(Product.of(productId1, "productName", price1, generateRandomStocks(10), true),
+                Product.of(productId2, "productName", price2, generateRandomStocks(20), true));
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
         var productMap = products.stream().collect(Collectors.toMap(Product::getId, p -> p));

--- a/src/test/java/com/abc/mart/payment/usecase/ProcessPaymentUsecaseTest.java
+++ b/src/test/java/com/abc/mart/payment/usecase/ProcessPaymentUsecaseTest.java
@@ -65,17 +65,18 @@ class ProcessPaymentUsecaseTest {
         var price2 = 20000;
 
         var orderMemberId = "memberId";
-        var products = List.of(Product.of(productId1, "productName", price1), Product.of(productId2, "productName", price2));
+        var products = List.of(Product.of(productId1, "productName", price1, 10, true), Product.of(productId2, "productName", price2, 20, true));
         var customer = Customer.from(Member.of(orderMemberId, "memberName", "email", "phoneNum"));
 
         var productMap = products.stream().collect(Collectors.toMap(Product::getId, p -> p));
 
-        var orderItemRequests = List.of(
-                new OrderRequest.OrderItemRequest(products.get(0).getId(), 10, 1),
-                new OrderRequest.OrderItemRequest(products.get(1).getId(), 3, 2)
+        var orderItems = List.of(
+                        OrderItem.of(products.get(0), 10),
+                        OrderItem.of(products.get(1), 3)
+
         );
 
-        var order = Order.createOrder(customer, productMap, orderItemRequests);
+        var order = Order.createOrder(orderItems, customer);
 
         when(orderRepository.findById(orderId)).thenReturn(order);
 

--- a/src/test/java/com/abc/mart/payment/usecase/ProcessPaymentUsecaseTest.java
+++ b/src/test/java/com/abc/mart/payment/usecase/ProcessPaymentUsecaseTest.java
@@ -77,7 +77,7 @@ class ProcessPaymentUsecaseTest {
 
         );
 
-        var order = Order.createOrder(orderItems, customer, 0);
+        var order = Order.createOrder(orderItems, customer);
 
         when(orderRepository.findById(orderId)).thenReturn(order);
 

--- a/src/test/java/com/abc/mart/payment/usecase/ProcessPaymentUsecaseTest.java
+++ b/src/test/java/com/abc/mart/payment/usecase/ProcessPaymentUsecaseTest.java
@@ -72,12 +72,12 @@ class ProcessPaymentUsecaseTest {
         var productMap = products.stream().collect(Collectors.toMap(Product::getId, p -> p));
 
         var orderItems = List.of(
-                        OrderItem.of(products.get(0), 10),
-                        OrderItem.of(products.get(1), 3)
+                        OrderItem.of(products.get(0), price1,10),
+                        OrderItem.of(products.get(1), price2, 3)
 
         );
 
-        var order = Order.createOrder(orderItems, customer);
+        var order = Order.createOrder(orderItems, customer, 0);
 
         when(orderRepository.findById(orderId)).thenReturn(order);
 

--- a/src/test/java/com/abc/mart/product/usecase/ProductManagementUsecaseTest.java
+++ b/src/test/java/com/abc/mart/product/usecase/ProductManagementUsecaseTest.java
@@ -1,14 +1,20 @@
 package com.abc.mart.product.usecase;
 
+import com.abc.mart.product.Stock;
 import com.abc.mart.product.domain.Product;
 import com.abc.mart.product.domain.repository.ProductRepository;
+import com.abc.mart.product.usecase.dto.ReqStock;
 import com.abc.mart.product.usecase.dto.ResFetchStock;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static com.abc.mart.test.TestStubCreator.generateRandomStocks;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -21,7 +27,7 @@ class ProductManagementUsecaseTest {
     void testProductStatusManagement() {
         // given
         var productId = "productId1";
-        var product = Product.of(productId, "productName", 100, 10, true);
+        var product = Product.of(productId, "productName", 100, generateRandomStocks(10), true);
         when(productRepository.findByProductId(productId)).thenReturn(Optional.of(product));
 
         // when
@@ -37,8 +43,13 @@ class ProductManagementUsecaseTest {
         // given
         var productId1 = "productId1";
         var productId2 = "productId2";
-        var product1 = Product.of(productId1, "productName1", 100, 10, true);
-        var product2 = Product.of(productId2, "productName2", 200, 5, true);
+
+        var product1 = Product.of(productId1, "productName1", 100,
+                generateRandomStocks(3), true);
+
+        var product2 = Product.of(productId2, "productName2", 200,
+                generateRandomStocks(2), true);
+
         when(productRepository.findAllByProductIdAndIsAvailable(List.of(productId1, productId2), true))
                 .thenReturn(List.of(product1, product2));
 
@@ -47,24 +58,29 @@ class ProductManagementUsecaseTest {
 
         // then
         assertEquals(2, result.size());
-        assertEquals(new ResFetchStock(productId1, "productName1", 10), result.get(0));
-        assertEquals(new ResFetchStock(productId2, "productName2", 5), result.get(1));
+        assertEquals(new ResFetchStock(productId1, "productName1", 3), result.get(0));
+        assertEquals(new ResFetchStock(productId2, "productName2", 2), result.get(1));
     }
 
     @Test
     void testOrderStock() {
         // given
         var productId = "productId1";
-        var product = Product.of(productId, "productName", 100, 10, true);
+        var product = Product.of(productId, "productName", 100,
+                generateRandomStocks(3), true);
         when(productRepository.findByProductId(productId)).thenReturn(Optional.of(product));
 
         // when
-        usecase.orderStock(productId, 5);
+        usecase.orderStock(productId, new ArrayList<>(Arrays.asList(new ReqStock("1",LocalDateTime.of(2023, 10, 1, 0, 0, 1, 456)),
+                new ReqStock("2", LocalDateTime.of(2023, 10, 1, 0, 0,2, 234)))));
+
 
         // then
         verify(productRepository).save(product);
-        assertEquals(15, product.getStockCount());
+        assertEquals(5, product.getStocks().size());
     }
+
+
 
     @Test
     void testProductNotFound() {
@@ -74,6 +90,7 @@ class ProductManagementUsecaseTest {
 
         // when & then
         assertThrows(IllegalArgumentException.class, () -> usecase.productStatusManagement(productId, true));
-        assertThrows(IllegalArgumentException.class, () -> usecase.orderStock(productId, 5));
+        assertThrows(IllegalArgumentException.class, () -> usecase.orderStock(productId,
+                List.of(new ReqStock("1", LocalDateTime.of(2023, 10, 1, 0, 0, 1, 456)))));
     }
 }

--- a/src/test/java/com/abc/mart/test/TestStubCreator.java
+++ b/src/test/java/com/abc/mart/test/TestStubCreator.java
@@ -1,0 +1,23 @@
+package com.abc.mart.test;
+
+import com.abc.mart.product.Stock;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class TestStubCreator {
+
+    public static List<Stock> generateRandomStocks(int count) {
+        var random = new Random();
+        var stocks = new ArrayList<Stock>();
+        for (int i = 0; i < count; i++) {
+            stocks.add(Stock.of(String.valueOf(i+1), LocalDateTime.of(
+                    2025, random.nextInt(12) + 1, random.nextInt(28) + 1,
+                    random.nextInt(24), random.nextInt(60), random.nextInt(60), random.nextInt(1000)
+            )));
+        }
+        return stocks;
+    }
+}


### PR DESCRIPTION
## 기존과 수정된 부분 
### 재고 입고 일자에 따라 쿠폰을 적용 하는 요구사항이 생김
- 재고를 직접 관리해야하면서 수정 필요했던 부분
	- 재고를 추적할 수 있어야 함
	- 어떤 재고가 나갔는지, 어떤 재고가 다시 환불되어 입고 처리되었는지 추적이 필요함.
	- 따라서 재고 갯수만 기록하던 데에서 -> 재고를 실제 entity로 수정함.

### 재고 출고/환불 시 복구 로직 개선
```
- 문제 1) 재고 출고 시 재고를 hard delete할 것인가, soft delete할 것인가?

  - 기존에는 재고를 출고 시 삭제했는데, 이렇게 하면 어떤 재고가 주문에 포함됐는지 확인하기 어려워짐. 
    → 환불 시 어떤 재고를 다시 원상 복구시켜야 하는지 알 수 없는 문제가 생김

  - 그래서 이제는 재고를 삭제하지 않고, 상태만 "sold"로 변경하여 soft delete 형태로 보존함. 
     주문(Order)에는 출고된 재고의 Stock ID를 OrderItem에 함께 기록함.

  - 이렇게 하면 재고는 여전히 Product의 일부로 존재하면서도, 주문 도메인에서도 어떤 재고가 출고됐는지 추적할 수 있음. 
    → 두 도메인에서 모두 일관되게 관리 가능

  - 환불 시에는 주문에 포함되어 있는 재고를 추적하여 실제로 출고된 재고의 상태를 원상 복구하는 로직을 추가함.

- 문제 2) 주문 시 어떤 재고를 출고할 것인가?

  - sorting process를 만들어, 아직 팔리지 않은 재고 중 가장 오래된 것부터 먼저 출고될 수 있도록 함.
    (실무에서는 쿼리 정렬로 처리할 듯 함)
```

### 주문 시 추가된 기능
- order 시 쿠폰 사용하여 할인하고, 쿠폰 사용 이력 생성하는 로직 추가



## 신규 생성 부분 
<img width="606" alt="image" src="https://github.com/user-attachments/assets/b29e7616-d12b-4bdd-86a3-008422b91a10" />

- 쿠폰 유즈케이스는 스토어에서 쿠폰 생성 -> 개인에게 발급 -> 주문 시 사용하여 할인받음의 흐름을 따른다고 판단함.
- Coupon, MemberIssuedCoupon, CouponRedemptionHistory 추가

### 쿠폰 도메인 생성
- 유연한 대응을 위해 DB에 쿠폰의 상세 정책을 저장하도록 함. 
	- 쿠폰은 타입별로 다른 할인 정책을 갖고 있으므로, CouponPolicy라는 인터페이스를 생성하여, 각각 쿠폰에 맞는 할인 정책을 구현할 수 있도록 함.
			ex) 재고 할인 - 재고의 입고일짜 확인하여 조건에 맞는 경우 할인 적용이라는 정책이 있음.
- `Order` 생성 → 본인에게 발급된 `membersIssuedCoupon` 사용 -> Coupon의  `CouponPolicy` 조회하여 정책에 따라 할인 적용 -> 할인 적용 이력 생성하여 저장
	- CouponService에서는 coupon type에 따라 달라지는 couponPolicy 사용하여 할인 금액 계산.
		- 재고 쿠폰 : 입고 일자에 따라 가장 할인율이 높은 쿠폰 선택
			- 60일 전에 입고된 재고인 경우 20일 쿠폰, 40일 쿠폰을 갖고 있다면 40일 쿠폰 선택.
		- 전체 쿠폰 : 쿼리로 처리 
		
### MemberIssuedCoupon Entity 생성
- 쿠폰 정책(Coupon)과 실제 발급 내역을 분리하고, 회원별로 발급된 쿠폰의 상태와 이력을 관리하기 위해 설계한 entity.

### 쿠폰 사용 기록을 어떻게 관리할 것인가?
- 이제 개인에게 발급된 쿠폰을 실제로 사용하여 얼마나 할인되었는지 저장하는 기록이 필요하다.
- 요구사항
	- 재고 할인 쿠폰과 전체 할인 쿠폰, 두 가지 종류의 쿠폰이 존재함.
	- 이해한 내용 - 재고 할인 쿠폰은 품목(OrderItem)별로 적용된다, 전체 할인 쿠폰은 OrderItem의 총 가격을 전부 합산한 주문(Order) 전체 가격에 대해 적용된다. 
- 1차 시도
	- `OrderItem`에 재고(품목) 할인 쿠폰이 적용된 금액 필드를 추가함.
	- `Order`에는 전체(주문) 할인 쿠폰이 적용된 금액 필드를 추가함.
	- 총 할인 금액은 재고 할인 금액과 전체 할인 금액을 합산하여 계산함.
	- 다만, 쿠폰이 추가될 때마다 `Order`나 `OrderItem`에 할인 관련 필드가 계속해서 늘어나는 구조가 적절하지 않다고 판단함.
	- 쿠폰은 정책과 종류에 따라 다양한 방식으로 적용되기 때문에, 할인 금액을 직접 엔티티에 저장하기보다는 별도의 구조에서 관리하는 것이 더 바람직하다고 판단함.
- 2차 시도
	- `CouponRedemptionHistory` 인터페이스를 정의하고, 쿠폰 타입별로 구현체를 나누어 설계함.
		- 각 구현체는 쿠폰이 적용된 대상(`Order` 또는 `OrderItem`)의 ID를 갖도록 구성함.
			- 쿠폰 적용 대상이 주문 품목 단위든 주문 전체든 관계없이 일관된 구조로 이력을 기록할 수 있음.
			- 쿠폰 타입이 늘어나더라도 구현체만 추가하면 되므로 유연하게 확장이 가능함.
		- 다른 커머스 서비스들을 보면 쿠폰의 타입에 따라 할인된 가격을 주문에 기록하기 때문에 타입별로 할인 금액을 계산할 수 있도록 CouponType 필드추가.
			- <img width="551" alt="image" src="https://github.com/user-attachments/assets/bb8eac5d-1e3c-473c-9ad5-45a1e09fa50d" />

	- 총 할인 금액은 `CouponRedemptionHistory`에서 할인 금액을 전부 합산하여 계산할 수 있음.
	
### 쿠폰 관련 기능
- 쿠폰 할인 별 판매 수량 계산 
	- 쿠폰별로 몇 개 씩 실제 주문에 사용되었는지 기능 구현 


## 더 개선해야 할 부분
	- 아직 쿠폰 사용 기록 (CouponHistory)과 - 유저에게 발급된 쿠폰(MemberIssuedCoupon)을 어떻게 연결해야 할지 뾰족하게 생각이 안남.
		- 그 이유 : 이렇게 되면 한 품목에서 재고 별로 다르게 할인 쿠폰이 적용된 것도 지금 싹 다 couponhistory로 이력 관리를 해야 함....
		- orderItem1의 재고 1에 20퍼 쿠폰 적용 기록 + orderItem2의 재고 3에 10퍼 쿠폰 적용된 기록 .. etc
		- 이게 맞는 건가?
	- 이것 때문에 각 쿠폰별로 판매된 금액 계산을 어떻게 해야 할지 아직 잘 모르겠어서 고민을 좀 더 해보려고함.. 다른 분들 것도 한번 참고해 보겠습니다.